### PR TITLE
fix: web-mode test failures (capacitor wrappers + audit log isolation)

### DIFF
--- a/lib/automation/audit.test.ts
+++ b/lib/automation/audit.test.ts
@@ -26,8 +26,16 @@ function row(overrides: Partial<AutomationAuditLogRow> = {}): AutomationAuditLog
   }
 }
 
+beforeEach(async () => {
+  // Drop the in-memory IDB so this test starts fresh — necessary because
+  // `fake-indexeddb/auto` keeps a process-wide IDBFactory that survives
+  // across test files in the same Jest worker, so prior runs can leak
+  // rows into our table.
+  await getDb().delete()
+  __resetDbForTesting()
+})
+
 afterEach(async () => {
-  // Drop the in-memory IDB so the next test starts fresh.
   await getDb().delete()
   __resetDbForTesting()
 })
@@ -40,6 +48,9 @@ describe("recordAuditRow", () => {
     expect(rows[0].command).toBe("click")
   })
 
+  // Inserting 5003 rows through fake-indexeddb (each in its own transaction
+  // that does put + count + possibly bulkDelete) is genuinely slow — bump
+  // the per-test timeout so the cap enforcement test has room to finish.
   it("enforces the 5000-newest cap by evicting oldest rows", async () => {
     // Insert AUTOMATION_AUDIT_CAP + 3 rows with strictly-increasing ts.
     for (let i = 0; i < AUTOMATION_AUDIT_CAP + 3; i++) {
@@ -52,7 +63,7 @@ describe("recordAuditRow", () => {
     // Oldest 3 should have been evicted.
     const oldest = all[all.length - 1]
     expect(oldest.ts).toBe(1_000_000 + 3)
-  })
+  }, 30_000)
 })
 
 describe("listAuditRows filters", () => {

--- a/lib/capacitor/_shared.ts
+++ b/lib/capacitor/_shared.ts
@@ -77,9 +77,20 @@ export async function withPlugin<P, R>(
  * Build a default loader that dynamic-imports a plugin module by name and
  * returns the named export. The `webpackIgnore` comment keeps the web bundle
  * from trying to resolve the native package.
+ *
+ * On web (no Tauri, no Capacitor native) the loader short-circuits with a
+ * throw so `withPlugin` collapses to `{ kind: "unsupported" }`. Without
+ * this guard, Capacitor's web shim returns a Proxy whose `.then` getter
+ * throws ("Haptics.then() is not implemented on web") the moment we
+ * `await` the resolved export — which would surface as an unhandled
+ * rejection in tests and a confusing runtime crash for users who happen
+ * to load the wrappers in plain browser context.
  */
 export function makeDefaultLoader<P>(moduleId: string, exportName: string): () => Promise<P> {
   return async () => {
+    if (detectNativePlatform() === "web") {
+      throw new Error(`${moduleId} not available on web`)
+    }
     const mod = (await import(/* webpackIgnore: true */ moduleId)) as Record<string, unknown>
     const exported = mod[exportName]
     if (!exported) {


### PR DESCRIPTION
## Summary

Eliminates the last batch of test failures still present after #74 merged: the capacitor wrapper contract tests + the automation audit log Dexie mirror. Goes from **8 failing suites / 11 failing tests** to **0 failures** — 1342/1342 suites, 16154/16190 tests passing.

### Capacitor wrappers (`lib/capacitor/_shared.ts`)

`makeDefaultLoader` now short-circuits with a throw when `detectNativePlatform() === "web"`. Without this guard the dynamic `import("@capacitor/haptics")` (and friends) resolves to Capacitor's web shim — a Proxy whose `.then` getter throws *"Haptics.then() is not implemented on web"* the moment our await touches it. That surfaced as 4 hard failures in `lib/capacitor/_contract.test.ts` (haptics / toast / dialog / share) plus a flake in `components/mobile/connector/draft-approval-panel.test.tsx` whose pull-to-refresh flow calls `selectionFeedback()`.

Custom-loader code paths (every wrapper's own unit tests) are unaffected because they pass their own loaders straight to `withPlugin`.

### Audit log test isolation (`lib/automation/audit.test.ts`)

- Add a `beforeEach` that drops the in-memory IDB before each test (not just after), so rows leaked into the process-wide `fake-indexeddb` by earlier test files in the same Jest worker do not pollute this suite's assertions (`clearAuditLog` was seeing 4 rows where 2 were expected).
- Bump the 5000-newest cap test's per-`it` timeout to 30 s. Inserting 5003 rows through fake-indexeddb at ~one transaction per row is genuinely slow (~2.4 s in practice, but the 5 s default left no margin under load).

## Test plan

- [x] `pnpm test lib/capacitor/_contract.test.ts` → 9/9 pass
- [x] `pnpm test lib/capacitor components/mobile/connector/draft-approval-panel.test.tsx` → 20 suites / 143 tests pass
- [x] `pnpm test lib/automation/audit.test.ts` → 6/6 pass (in isolation)
- [x] `pnpm test` (full suite) → **1342/1342 suites, 16154/16190 tests pass** (36 deliberately-skipped tests untouched)
- [x] `pnpm lint` → 0 errors
- [x] `pnpm typecheck` → clean