### PR TITLE
chore(deps): bump 5 Rust crates to new majors + migrate APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -51,8 +51,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -62,8 +73,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -135,12 +146,6 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ambient-authority"
@@ -754,12 +759,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -767,7 +773,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -880,12 +885,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1274,7 +1297,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1296,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
 dependencies = [
  "aead",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "subtle",
 ]
@@ -1347,8 +1379,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1359,7 +1391,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -1390,9 +1422,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1476,6 +1518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,7 +1547,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tiny_http",
  "ureq 2.12.1",
@@ -1511,7 +1559,7 @@ dependencies = [
 name = "cognia-next"
 version = "0.1.0"
 dependencies = [
- "aes",
+ "aes 0.9.0",
  "aes-gcm",
  "anyhow",
  "async-trait",
@@ -1519,7 +1567,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "bytes",
- "cbc",
+ "cbc 0.2.1",
  "chrono",
  "clap",
  "cron",
@@ -1535,7 +1583,7 @@ dependencies = [
  "git2",
  "gray_matter",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "ignore",
  "image",
  "jsonwebtoken",
@@ -1564,7 +1612,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.11.0",
  "sqlite-vec",
  "subtle",
  "syslog",
@@ -1681,6 +1729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,10 +1839,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1925,13 +1994,14 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.12.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
 dependencies = [
  "chrono",
- "nom 7.1.3",
  "once_cell",
+ "phf 0.11.3",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2007,6 +2077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,7 +2094,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -2051,7 +2130,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -2061,9 +2149,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2213,7 +2301,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -2392,10 +2480,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2551,16 +2651,16 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f016db07b91e9d79cc60a152c163d3f0ce2d4c0173cb3964de3526aab6e07fa"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "aes-gcm",
  "async-trait",
  "bytecheck 0.8.2",
  "byteorder",
- "cbc",
+ "cbc 0.1.2",
  "ccm",
  "chacha20poly1305",
  "der-parser",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "p256",
  "p384",
@@ -2573,7 +2673,7 @@ dependencies = [
  "rustls",
  "sec1",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
@@ -2630,7 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2656,7 +2756,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2675,7 +2775,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2888,7 +2988,7 @@ dependencies = [
  "log",
  "regex",
  "registry",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "windows 0.58.0",
 ]
@@ -3716,12 +3816,12 @@ dependencies = [
 
 [[package]]
 name = "gray_matter"
-version = "0.2.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8666976c40b8633f918783969b6681a3ddb205f29150348617de425d85a3e3bd"
+checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
 dependencies = [
  "serde",
- "serde_json",
+ "thiserror 2.0.18",
  "yaml-rust2",
 ]
 
@@ -3834,7 +3934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
- "allocator-api2",
  "serde",
 ]
 
@@ -3865,11 +3964,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3911,7 +4010,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3920,7 +4019,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4003,6 +4111,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4385,8 +4502,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4867,14 +4994,14 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19c97a761fc86953c5b885422b22c891dbf5bcb9dcc99d0110d6ce4c052759f0"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "libc",
  "log",
  "nix 0.29.0",
  "nom 8.0.0",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",
 ]
@@ -5061,7 +5188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6345,7 +6472,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6357,7 +6484,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6479,12 +6606,22 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -6494,8 +6631,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6505,7 +6652,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6514,11 +6674,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6648,7 +6817,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -6660,7 +6829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -7576,7 +7745,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -8192,7 +8361,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -8440,8 +8609,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8451,8 +8620,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8543,7 +8723,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -8818,7 +8998,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -8828,8 +9008,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -9177,7 +9357,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -9650,7 +9830,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -10581,7 +10761,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -11334,7 +11514,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -11426,7 +11606,7 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smol_str",
  "stun",
  "thiserror 1.0.69",
@@ -11535,12 +11715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e437f74b04f42049192e25cbb33c21c86be308875e6afe14cf8e28d1ffa35ac"
 dependencies = [
  "aead",
- "aes",
+ "aes 0.8.4",
  "aes-gcm",
  "byteorder",
  "bytes",
  "ctr",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "rtcp",
  "rtp",
@@ -12624,7 +12804,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",
@@ -12779,13 +12959,13 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.8.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink 0.8.4",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -121,7 +121,7 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 # (the `bundled` feature does).
 sqlite-vec = "0.1"
 
-gray_matter = { version = "0.2", default-features = false, features = ["yaml"] }
+gray_matter = { version = "0.3", default-features = false, features = ["yaml"] }
 wait-timeout = "0.2"
 # Cross-platform PTY backend for the integrated terminal (`src-tauri/src/terminal/`).
 # Uses ConPTY on Windows (Win10 1809+), forkpty on macOS/Linux. wezterm's
@@ -157,25 +157,25 @@ base64 = "0.22"
 # firing via a small tokio loop in `src-tauri/src/workflow/triggers/cron_daemon.rs`
 # rather than pull in `tokio-cron-scheduler` (which is heavier and has its
 # own runtime semantics that conflict with our existing scheduler module).
-cron = "0.12"
+cron = "0.16"
 
 # MCP HTTP server — axum for the inbound listener, subtle for constant-time
 # bearer-token comparison, tower-http for body-size limits.
 axum = { version = "0.8", features = ["macros", "ws"] }
 # axum-server (M2.9) — TLS termination for the companion API. `tls-rustls`
 # pulls in rustls + ring; matches the project's existing tokio-rustls path.
-axum-server = { version = "0.7", features = ["tls-rustls"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 subtle = "2"
 tower = { version = "0.5", features = ["util", "limit", "timeout"] }
 tower-http = { version = "0.6", features = ["limit", "trace", "cors"] }
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 ed25519-dalek = "2"
 hex = "0.4"
 url = "2"
 aes-gcm = { version = "0.10", features = ["aes"] }
-aes = "0.8"
-cbc = { version = "0.1", features = ["alloc"] }
+aes = "0.9"
+cbc = { version = "0.2", features = ["alloc"] }
 rand = "0.8"
 jsonwebtoken = "9"
 serde_urlencoded = "0.7"

--- a/src-tauri/src/automation/commands.rs
+++ b/src-tauri/src/automation/commands.rs
@@ -186,6 +186,21 @@ impl CallContext {
     fn surface(&self) -> Surface {
         self.surface.unwrap_or(Surface::Workflow)
     }
+
+    /// Project the renderer-supplied context into the borrow-tied
+    /// [`ActionFacts`](super::policy::ActionFacts) the policy engine matches
+    /// against. Mirrors `dispatcher::GateContext::facts`; production gating
+    /// runs on the converted `GateContext`, so this helper is test-only.
+    #[cfg(test)]
+    fn facts(&self) -> super::policy::ActionFacts<'_> {
+        super::policy::ActionFacts {
+            process_name: self.process_name.as_deref(),
+            window_title: self.window_title.as_deref(),
+            target_url: self.target_url.as_deref(),
+            click_x: self.click_x,
+            click_y: self.click_y,
+        }
+    }
 }
 
 

--- a/src-tauri/src/companion_api/server.rs
+++ b/src-tauri/src/companion_api/server.rs
@@ -151,7 +151,16 @@ pub async fn spawn_server(
         // `into_make_service_with_connect_info::<SocketAddr>()` so the
         // `pre_auth_rate_limit` middleware can extract the peer IP for its
         // per-source-IP token bucket (see `middleware::pre_auth_rate_limit`).
-        let result = axum_server::from_tcp_rustls(std_listener, rustls_config)
+        // axum-server 0.8 made `from_tcp_rustls` fallible (it now builds the
+        // rustls acceptor eagerly), so unwrap the `Result` before chaining.
+        let server = match axum_server::from_tcp_rustls(std_listener, rustls_config) {
+            Ok(server) => server,
+            Err(e) => {
+                log::warn!("companion-api server failed to build TLS acceptor: {e}");
+                return;
+            }
+        };
+        let result = server
             .handle(serve_handle)
             .serve(app.into_make_service_with_connect_info::<SocketAddr>())
             .await;

--- a/src-tauri/src/companion_api/signaling/envelope.rs
+++ b/src-tauri/src/companion_api/signaling/envelope.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src-tauri/src/connectors/axum_app.rs
+++ b/src-tauri/src/connectors/axum_app.rs
@@ -425,7 +425,7 @@ mod tests {
         if !keyring_available() {
             return;
         }
-        use hmac::{Hmac, Mac};
+        use hmac::{Hmac, KeyInit, Mac};
         use sha2::Sha256;
         type HmacSha256 = Hmac<Sha256>;
 
@@ -530,7 +530,7 @@ mod tests {
         if !keyring_available() {
             return;
         }
-        use aes::cipher::{block_padding::Pkcs7, BlockEncryptMut, KeyIvInit};
+        use aes::cipher::{block_padding::Pkcs7, BlockModeEncrypt, KeyIvInit};
         use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
         use rand::RngCore;
         use sha2::{Digest, Sha256};
@@ -545,10 +545,11 @@ mod tests {
 
         let plaintext = br#"{"schema":"2.0","header":{"token":"vtok-2"}}"#;
         let key_bytes = Sha256::digest(b"the-encrypt-key");
+        let key_arr: [u8; 32] = key_bytes.as_slice().try_into().unwrap();
         let mut iv = [0u8; 16];
         rand::thread_rng().fill_bytes(&mut iv);
-        let ciphertext = Aes256CbcEnc::new(key_bytes.as_slice().into(), &iv.into())
-            .encrypt_padded_vec_mut::<Pkcs7>(plaintext);
+        let ciphertext = Aes256CbcEnc::new(&key_arr.into(), &iv.into())
+            .encrypt_padded_vec::<Pkcs7>(plaintext);
         let mut combined = iv.to_vec();
         combined.extend_from_slice(&ciphertext);
         let encoded = BASE64.encode(combined);

--- a/src-tauri/src/connectors/sigverify/lark.rs
+++ b/src-tauri/src/connectors/sigverify/lark.rs
@@ -1,4 +1,4 @@
-use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit};
+use aes::cipher::{block_padding::Pkcs7, BlockModeDecrypt, KeyIvInit};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use sha2::{Digest, Sha256};
 
@@ -49,7 +49,11 @@ pub fn verify_token(provided: Option<&str>, expected: &str) -> Result<(), SigErr
 /// The decrypted plaintext bytes on success, or a `SigError` on failure.
 pub fn decrypt_body(encrypted_b64: &str, encrypt_key: &str) -> Result<Vec<u8>, SigError> {
     // Derive 32-byte AES key from the encrypt_key string via SHA-256
-    let key_bytes = Sha256::digest(encrypt_key.as_bytes());
+    let digest = Sha256::digest(encrypt_key.as_bytes());
+    let key_arr: [u8; 32] = digest
+        .as_slice()
+        .try_into()
+        .map_err(|_| SigError::Mismatch)?;
 
     // Base64-decode the ciphertext
     let raw = BASE64
@@ -65,33 +69,33 @@ pub fn decrypt_body(encrypted_b64: &str, encrypt_key: &str) -> Result<Vec<u8>, S
 
     let iv_arr: [u8; 16] = iv.try_into().map_err(|_| SigError::Mismatch)?;
 
-    // Decrypt in-place
-    let mut buf = ciphertext.to_vec();
-    let decryptor = Aes256CbcDec::new(key_bytes.as_slice().into(), &iv_arr.into());
+    // Decrypt with PKCS#7 unpadding (cbc 0.2 / cipher 0.5 API)
+    let decryptor = Aes256CbcDec::new(&key_arr.into(), &iv_arr.into());
     let plaintext = decryptor
-        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .decrypt_padded_vec::<Pkcs7>(ciphertext)
         .map_err(|_| SigError::Mismatch)?;
 
-    Ok(plaintext.to_vec())
+    Ok(plaintext)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes::cipher::{BlockEncryptMut, KeyIvInit};
+    use aes::cipher::{BlockModeEncrypt, KeyIvInit};
     use rand::RngCore;
 
     type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
 
     fn encrypt_body(plaintext: &[u8], encrypt_key: &str) -> String {
-        let key_bytes = Sha256::digest(encrypt_key.as_bytes());
+        let digest = Sha256::digest(encrypt_key.as_bytes());
+        let key_arr: [u8; 32] = digest.as_slice().try_into().unwrap();
 
         // Random IV
         let mut iv = [0u8; 16];
         rand::thread_rng().fill_bytes(&mut iv);
 
-        let ciphertext = Aes256CbcEnc::new(key_bytes.as_slice().into(), &iv.into())
-            .encrypt_padded_vec_mut::<Pkcs7>(plaintext);
+        let ciphertext = Aes256CbcEnc::new(&key_arr.into(), &iv.into())
+            .encrypt_padded_vec::<Pkcs7>(plaintext);
 
         // Prepend IV to ciphertext, then base64-encode
         let mut combined = iv.to_vec();

--- a/src-tauri/src/connectors/sigverify/slack.rs
+++ b/src-tauri/src/connectors/sigverify/slack.rs
@@ -1,4 +1,4 @@
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 

--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -3,7 +3,7 @@
 // chat sidecar commands because they're sync, simple, and have no shared
 // state beyond the filesystem.
 
-use gray_matter::{engine::YAML, Matter};
+use gray_matter::{engine::YAML, Matter, Pod};
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -329,7 +329,13 @@ fn collect_command_files(root: &Path, scope: &str, out: &mut Vec<SlashCommandFil
             Err(_) => continue,
         };
         let name = rel.to_string_lossy().replace('\\', "/");
-        let parsed = matter.parse(&raw);
+        // gray_matter 0.3 made `parse` generic + fallible; `Pod` keeps the
+        // dynamic front-matter access this loop relies on. Skip files whose
+        // front matter fails to parse (a malformed command file is unusable).
+        let parsed = match matter.parse::<Pod>(&raw) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
         let body = parsed.content.trim_start().to_string();
         let mut description: Option<String> = None;
         let mut argument_hint: Option<String> = None;

--- a/src-tauri/src/workflow/triggers/webhook_router.rs
+++ b/src-tauri/src/workflow/triggers/webhook_router.rs
@@ -35,7 +35,7 @@ use axum::{
     routing::any,
     Router,
 };
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use parking_lot::RwLock;
 use serde::Serialize;
 use sha2::Sha256;
@@ -419,7 +419,7 @@ fn verify_hmac_signature(
     let Ok(provided) = decode_hex(hex_part) else {
         return false;
     };
-    let mut mac = match <Hmac<Sha256> as Mac>::new_from_slice(secret.as_bytes()) {
+    let mut mac = match <Hmac<Sha256> as KeyInit>::new_from_slice(secret.as_bytes()) {
         Ok(m) => m,
         Err(_) => return false,
     };
@@ -581,7 +581,7 @@ mod tests {
         use axum::http::HeaderValue;
         let secret = "shh";
         let body = Bytes::from_static(b"{\"hello\":\"world\"}");
-        let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(secret.as_bytes()).unwrap();
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(secret.as_bytes()).unwrap();
         mac.update(&body);
         let hex: String = mac
             .finalize()
@@ -662,7 +662,7 @@ mod tests {
         use axum::http::HeaderValue;
         let secret = "ghs";
         let body = Bytes::from_static(b"{\"action\":\"opened\"}");
-        let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(secret.as_bytes()).unwrap();
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(secret.as_bytes()).unwrap();
         mac.update(&body);
         let hex: String = mac
             .finalize()
@@ -686,7 +686,7 @@ mod tests {
         use axum::http::HeaderValue;
         let secret = "ghs";
         let body = Bytes::from_static(b"x");
-        let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(secret.as_bytes()).unwrap();
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(secret.as_bytes()).unwrap();
         mac.update(&body);
         let hex: String = mac
             .finalize()
@@ -733,7 +733,7 @@ mod tests {
         let bound = router.start(recorder.clone(), 0).await.unwrap();
 
         let body = "{\"a\":1}";
-        let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(b"shh").unwrap();
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(b"shh").unwrap();
         mac.update(body.as_bytes());
         let hex: String = mac
             .finalize()


### PR DESCRIPTION
## What

Lands the 5 Rust dependency **major** bumps that dependabot opened as bare
version bumps (#58, #59, #60, #61, #76) but which don't compile without
companion-crate bumps + source API migrations.

| Bump | Companion | Migrated call sites |
|------|-----------|---------------------|
| sha2 0.10 → 0.11 | hmac 0.12 → **0.13** | `slack` / `envelope` / `webhook_router` / `axum_app` — `new_from_slice` moved from the `Mac` trait to `KeyInit` (digest 0.11) |
| aes 0.8 → 0.9 | cbc 0.1 → **0.2** | `lark` / `axum_app` — `BlockEncryptMut`/`BlockDecryptMut` → `BlockModeEncrypt`/`BlockModeDecrypt`; padded helpers → `*_padded_vec` (cipher 0.5) |
| axum-server 0.7 → 0.8 | — | `server` — `from_tcp_rustls` is now fallible |
| gray_matter 0.2 → 0.3 | — | `files` — `parse` is generic + fallible; `parse::<Pod>` preserves dynamic front-matter access |
| cron 0.12 → 0.16 | — | none |

The 10 Capacitor 7→8 dependabot PRs (#63–#72) were already auto-closed by
dependabot — that migration landed earlier in `293ac700`.

## Also (second commit)

Restores the missing `CallContext::facts()` `#[cfg(test)]` helper in
`automation/commands.rs`, which was breaking test-target compilation —
pre-existing and unrelated to the dependency bumps. Mirrors
`dispatcher::GateContext::facts()`.

## Verification

- `cargo check` (lib + bins): **clean**
- `cargo check --all-targets` (incl. all tests): **clean**
- Tauri `cargo test` cannot launch on the dev Windows host (pre-existing
  WebView2 limitation); execution should run in CI.

Supersedes #58, #59, #60, #61, #76 (closed in favour of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
