### PR TITLE
fix: sidecar install/bundle layout and enigo F-key mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "packageManager": "pnpm@10.30.3",
   "scripts": {
     "prepare": "husky",
+    "postinstall": "pnpm run sidecar:install && pnpm run sidecar:vscode:build",
     "predev": "node scripts/build/download-cubism-core.mjs && node scripts/build/clean-stale-turbopack-cache.mjs && node scripts/build/copy-monaco-assets.mjs && node scripts/build/build-builtin-skills.mjs",
     "prebuild": "node scripts/build/download-cubism-core.mjs && node scripts/build/copy-monaco-assets.mjs && node scripts/build/build-vscode-ext-host-sidecar.mjs && node scripts/build/build-builtin-skills.mjs",
     "skills:build": "node scripts/build/build-builtin-skills.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,49 +717,6 @@ importers:
         specifier: '>=5.0.0'
         version: 6.0.3
 
-  sidecar:
-    dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.71
-        version: 3.0.81(zod@4.4.3)
-      '@ai-sdk/cohere':
-        specifier: ^3.0.32
-        version: 3.0.36(zod@4.4.3)
-      '@ai-sdk/google':
-        specifier: ^3.0.66
-        version: 3.0.80(zod@4.4.3)
-      '@ai-sdk/mcp':
-        specifier: ^1.0.48
-        version: 1.0.50(zod@4.4.3)
-      '@ai-sdk/mistral':
-        specifier: ^3.0.32
-        version: 3.0.37(zod@4.4.3)
-      '@ai-sdk/openai':
-        specifier: ^3.0.55
-        version: 3.0.67(zod@4.4.3)
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: latest
-        version: 0.3.177(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
-      ai:
-        specifier: ^6.0.168
-        version: 6.0.196(zod@4.4.3)
-      diff:
-        specifier: ^7.0.0
-        version: 7.0.0
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
-      pdfjs-dist:
-        specifier: ^5.7.284
-        version: 5.7.284
-      zod:
-        specifier: ^4.0.0
-        version: 4.4.3
-    optionalDependencies:
-      node-pty:
-        specifier: ^1.0.0
-        version: 1.1.0
-
 packages:
 
   '@adobe/css-tools@4.5.0':
@@ -789,12 +746,6 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@1.0.50':
-    resolution: {integrity: sha512-iLqDZ62ezEjBhTJgiAQ4D2tHG1q7INVhPx0uOPnxJTxxqVUzN4KqeWAd6j5hYNhsPqC7TPGRQHQqAa1Z/lu2jg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/mistral@3.0.37':
     resolution: {integrity: sha512-KkdaMjs4C2y+vrZWJE990E3ZxBFiOTHQ94ZlquuIttpphcqJTMxNoIpnKT/4UzMVWXL0BUEE2vs+1UEVXkN8Kg==}
     engines: {node: '>=18'}
@@ -809,12 +760,6 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.27':
     resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.29':
-    resolution: {integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -839,67 +784,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.177':
-    resolution: {integrity: sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.177':
-    resolution: {integrity: sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.177':
-    resolution: {integrity: sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.177':
-    resolution: {integrity: sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.177':
-    resolution: {integrity: sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.177':
-    resolution: {integrity: sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.177':
-    resolution: {integrity: sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.177':
-    resolution: {integrity: sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk@0.3.177':
-    resolution: {integrity: sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@anthropic-ai/sdk': '>=0.93.0'
-      '@modelcontextprotocol/sdk': ^1.29.0
-      zod: ^4.0.0
-
-  '@anthropic-ai/sdk@0.104.1':
-    resolution: {integrity: sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -3716,9 +3600,6 @@ packages:
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
-  '@stablelib/base64@1.0.1':
-    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -5875,10 +5756,6 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
-    engines: {node: '>=0.3.1'}
-
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -6357,9 +6234,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -7489,10 +7363,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -8275,9 +8145,6 @@ packages:
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
-
-  node-pty@1.1.0:
-    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
@@ -9324,9 +9191,6 @@ packages:
   standardized-audio-context@25.3.77:
     resolution: {integrity: sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==}
 
-  standardwebhooks@1.0.0:
-    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
@@ -9702,9 +9566,6 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -10181,7 +10042,7 @@ packages:
     engines: {node: '>=20'}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true
@@ -10366,13 +10227,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/mcp@1.0.50(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      pkce-challenge: 5.0.1
-      zod: 4.4.3
-
   '@ai-sdk/mistral@3.0.37(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -10386,13 +10240,6 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@4.0.29(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
@@ -10424,52 +10271,6 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
-
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.177':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk@0.3.177(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.104.1(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      zod: 4.4.3
-    optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.177
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.177
-
-  '@anthropic-ai/sdk@0.104.1(zod@4.4.3)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
-    optionalDependencies:
-      zod: 4.4.3
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -13806,8 +13607,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@stablelib/base64@1.0.1': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -15956,8 +15755,6 @@ snapshots:
 
   diff@4.0.4: {}
 
-  diff@7.0.0: {}
-
   diff@8.0.4: {}
 
   dingbat-to-unicode@1.0.1: {}
@@ -16675,8 +16472,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -18094,11 +17889,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      ts-algebra: 2.0.0
-
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -19191,11 +18981,6 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
-
-  node-pty@1.1.0:
-    dependencies:
-      node-addon-api: 7.1.1
-    optional: true
 
   node-releases@2.0.47: {}
 
@@ -20580,11 +20365,6 @@ snapshots:
       automation-events: 7.1.19
       tslib: 2.8.1
 
-  standardwebhooks@1.0.0:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      fast-sha256: 1.3.0
-
   state-local@1.0.7: {}
 
   stats-gl@2.4.2(@types/three@0.184.1)(three@0.184.0):
@@ -21022,8 +20802,6 @@ snapshots:
   troika-worker-utils@0.52.0: {}
 
   trough@2.2.0: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:

--- a/sidecar/.npmrc
+++ b/sidecar/.npmrc
@@ -1,0 +1,6 @@
+# The Tauri bundler copies `node_modules/**/*` into the app as resources
+# (see src-tauri/tauri.conf.json → bundle.resources). pnpm's default
+# symlinked `.pnpm` virtual store makes that glob traversal fail with
+# "os error 2" when it follows peer-dependency symlinks. Force a flat,
+# real-file (npm-like) layout with no symlinks so the resource copy works.
+node-linker=hoisted

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -29,5 +29,10 @@
   },
   "optionalDependencies": {
     "node-pty": "^1.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "node-pty"
+    ]
   }
 }

--- a/sidecar/pnpm-lock.yaml
+++ b/sidecar/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: latest
         version: 0.2.121(zod@4.4.1)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.1)
       ai:
         specifier: ^6.0.168
         version: 6.0.184(zod@4.4.1)
@@ -38,9 +41,16 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
+      pdfjs-dist:
+        specifier: ^5.7.284
+        version: 5.7.284
       zod:
         specifier: ^4.0.0
         version: 4.4.1
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.0.0
+        version: 1.1.0
 
 packages:
 
@@ -180,6 +190,81 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -482,6 +567,12 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -507,6 +598,10 @@ packages:
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pdfjs-dist@5.7.284:
+    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
@@ -770,6 +865,54 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1071,6 +1214,14 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-addon-api@7.1.1:
+    optional: true
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+    optional: true
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -1088,6 +1239,10 @@ snapshots:
   path-key@3.1.1: {}
 
   path-to-regexp@8.4.2: {}
+
+  pdfjs-dist@5.7.284:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   picomatch@2.3.2: {}
 

--- a/src-tauri/src/automation/platform/atspi/mod.rs
+++ b/src-tauri/src/automation/platform/atspi/mod.rs
@@ -302,7 +302,43 @@ fn named_to_enigo(n: NamedKey) -> enigo::Key {
         NamedKey::ArrowDown => enigo::Key::DownArrow,
         NamedKey::ArrowLeft => enigo::Key::LeftArrow,
         NamedKey::ArrowRight => enigo::Key::RightArrow,
-        NamedKey::F(n) => enigo::Key::F(n),
+        NamedKey::F(n) => function_key_to_enigo(n),
+    }
+}
+
+/// Map a function-key number (`F1`–`F24`, the range accepted by
+/// `parse_function_key`) onto enigo's discrete `Key::F1`…`Key::F24` variants.
+/// enigo 0.6 has no `Key::F(n)` tuple variant — each function key is its own
+/// enum variant. Out-of-range values fall back to `F1`; this is unreachable in
+/// practice because `parse_function_key` rejects anything outside `1..=24`
+/// before a `NamedKey::F` is ever constructed.
+fn function_key_to_enigo(n: u8) -> enigo::Key {
+    match n {
+        1 => enigo::Key::F1,
+        2 => enigo::Key::F2,
+        3 => enigo::Key::F3,
+        4 => enigo::Key::F4,
+        5 => enigo::Key::F5,
+        6 => enigo::Key::F6,
+        7 => enigo::Key::F7,
+        8 => enigo::Key::F8,
+        9 => enigo::Key::F9,
+        10 => enigo::Key::F10,
+        11 => enigo::Key::F11,
+        12 => enigo::Key::F12,
+        13 => enigo::Key::F13,
+        14 => enigo::Key::F14,
+        15 => enigo::Key::F15,
+        16 => enigo::Key::F16,
+        17 => enigo::Key::F17,
+        18 => enigo::Key::F18,
+        19 => enigo::Key::F19,
+        20 => enigo::Key::F20,
+        21 => enigo::Key::F21,
+        22 => enigo::Key::F22,
+        23 => enigo::Key::F23,
+        24 => enigo::Key::F24,
+        _ => enigo::Key::F1,
     }
 }
 
@@ -533,5 +569,20 @@ mod tests {
         // so verify the API exists and returns *a* bool (the real
         // detection is exercised in CI on a Wayland host).
         let _: bool = is_pure_wayland_without_xtools();
+    }
+
+    #[test]
+    fn function_keys_map_to_discrete_enigo_variants() {
+        assert_eq!(function_key_to_enigo(1), enigo::Key::F1);
+        assert_eq!(function_key_to_enigo(12), enigo::Key::F12);
+        assert_eq!(function_key_to_enigo(24), enigo::Key::F24);
+        // Out-of-range is unreachable via the parser but must stay total.
+        assert_eq!(function_key_to_enigo(0), enigo::Key::F1);
+        assert_eq!(function_key_to_enigo(99), enigo::Key::F1);
+    }
+
+    #[test]
+    fn named_f_key_routes_through_function_key_map() {
+        assert_eq!(named_to_enigo(NamedKey::F(5)), enigo::Key::F5);
     }
 }

--- a/src-tauri/src/automation/platform/ax/mod.rs
+++ b/src-tauri/src/automation/platform/ax/mod.rs
@@ -317,7 +317,41 @@ fn named_to_enigo(n: NamedKey) -> enigo::Key {
         NamedKey::ArrowDown => enigo::Key::DownArrow,
         NamedKey::ArrowLeft => enigo::Key::LeftArrow,
         NamedKey::ArrowRight => enigo::Key::RightArrow,
-        NamedKey::F(n) => enigo::Key::F(n),
+        NamedKey::F(n) => function_key_to_enigo(n),
+    }
+}
+
+/// Map a function-key number (`F1`–`F24`, the range accepted by
+/// `parse_function_key`) onto enigo's discrete `Key::F1`…`Key::F20` variants.
+/// enigo 0.6 has no `Key::F(n)` tuple variant — each function key is its own
+/// enum variant — and on macOS it only defines through `F20` (`F21`–`F24` are
+/// gated to Windows / non-macOS unix). `F21`–`F24` therefore clamp to `F20`,
+/// the highest function key the macOS backend can synthesize. The remaining
+/// `_` arm is unreachable: `parse_function_key` rejects anything outside
+/// `1..=24` before a `NamedKey::F` is ever constructed.
+fn function_key_to_enigo(n: u8) -> enigo::Key {
+    match n {
+        1 => enigo::Key::F1,
+        2 => enigo::Key::F2,
+        3 => enigo::Key::F3,
+        4 => enigo::Key::F4,
+        5 => enigo::Key::F5,
+        6 => enigo::Key::F6,
+        7 => enigo::Key::F7,
+        8 => enigo::Key::F8,
+        9 => enigo::Key::F9,
+        10 => enigo::Key::F10,
+        11 => enigo::Key::F11,
+        12 => enigo::Key::F12,
+        13 => enigo::Key::F13,
+        14 => enigo::Key::F14,
+        15 => enigo::Key::F15,
+        16 => enigo::Key::F16,
+        17 => enigo::Key::F17,
+        18 => enigo::Key::F18,
+        19 => enigo::Key::F19,
+        20..=24 => enigo::Key::F20,
+        _ => enigo::Key::F1,
     }
 }
 
@@ -459,5 +493,23 @@ mod tests {
         let r = snap_to_element_ref(&snap);
         assert!(r.0.starts_with("macos|"));
         assert!(r.0.contains("pid=42"));
+    }
+
+    #[test]
+    fn function_keys_map_to_discrete_enigo_variants() {
+        assert_eq!(function_key_to_enigo(1), enigo::Key::F1);
+        assert_eq!(function_key_to_enigo(12), enigo::Key::F12);
+        assert_eq!(function_key_to_enigo(19), enigo::Key::F19);
+        // macOS enigo caps at F20; F20–F24 all clamp to F20.
+        assert_eq!(function_key_to_enigo(20), enigo::Key::F20);
+        assert_eq!(function_key_to_enigo(24), enigo::Key::F20);
+        // Out-of-range is unreachable via the parser but must stay total.
+        assert_eq!(function_key_to_enigo(0), enigo::Key::F1);
+        assert_eq!(function_key_to_enigo(99), enigo::Key::F1);
+    }
+
+    #[test]
+    fn named_f_key_routes_through_function_key_map() {
+        assert_eq!(named_to_enigo(NamedKey::F(5)), enigo::Key::F5);
     }
 }


### PR DESCRIPTION
## What

Two build/runtime fixes that were sitting as uncommitted local changes.

### Build / install chain
- `postinstall` now runs `sidecar:install` + `sidecar:vscode:build` so a fresh `pnpm install` produces a runnable sidecar.
- `sidecar/.npmrc` forces a hoisted (npm-like) `node_modules` layout. pnpm's default `.pnpm` symlinked store makes the Tauri resource copy (`bundle.resources` glob) fail with `os error 2` when it follows peer-dependency symlinks.
- `node-pty` is allowed to run its build script via `pnpm.onlyBuiltDependencies`.

### Automation key synthesis (`src-tauri`)
- enigo 0.6 dropped the `Key::F(n)` tuple variant — each function key is now its own enum variant. Added `function_key_to_enigo` to map `F1`–`F24` onto the discrete variants in both the **atspi** (Linux) and **ax** (macOS) backends.
- macOS enigo only defines through `F20`, so `F21`–`F24` clamp to `F20`.
- Added unit coverage for both backends (`function_keys_map_to_discrete_enigo_variants`, `named_f_key_routes_through_function_key_map`).

## Notes
- The `lib/skills/built-in-catalog.generated.ts` tweak (a file-level `eslint-disable`) was dropped by `lint-staged`'s `eslint --fix` as an unused disable directive, so it is not part of this PR.
- pnpm lockfile churn is a consequence of the sidecar `.npmrc` / dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)