### PR TITLE
feat(plugin): support AgentENV API URLs for E2B sandbox

### DIFF
--- a/docs/content/docs/en/subsystems/sandbox/microvm-and-web.mdx
+++ b/docs/content/docs/en/subsystems/sandbox/microvm-and-web.mdx
@@ -1,6 +1,6 @@
 ---
 title: "microVM & Web"
-description: "The T4 e2b Firecracker microVM tier, the per-session tier router in microvm-bridge, the e2b workspace backend for the GitHub-delivery loop, the web code-execution stub, and the SandboxExecutionResult / consumption-metadata types."
+description: "The T4 e2b Firecracker microVM tier, the per-session tier router in microvm-bridge, the e2b workspace backend for Marketplace integrations, the web code-execution stub, and the SandboxExecutionResult / consumption-metadata types."
 ---
 
 # microVM & Web
@@ -11,8 +11,8 @@ description: "The T4 e2b Firecracker microVM tier, the per-session tier router i
   `lib/sandbox/microvm-bridge.ts` is the two-piece glue between the OS sandbox and the e2b microVM
   tier (T4): a per-session **active tier** map and a registry holding the **microVM exec
   implementation**. The `cognia-e2b-sandbox` plugin registers a real exec on activate
-  (`buildMicrovmExec`); the same plugin also provides an `E2BWorkspaceBackend` for the
-  GitHub-delivery Issue→PR loop. E2B-compatible self-hosted endpoints such as AgentENV can be
+  (`buildMicrovmExec`); the same plugin also provides an `E2BWorkspaceBackend` for Marketplace
+  integrations. E2B-compatible self-hosted endpoints such as AgentENV can be
   configured in that plugin's settings via the API URL field. `lib/sandbox/web/index.ts` is a
   deliberate **stub** — the web code-execution runtime is not shipped. `types/system/sandbox.ts`
   carries the cross-boundary result and consumption-metadata shapes.
@@ -98,25 +98,34 @@ try {
   )) as { Sandbox?: unknown }
 } catch {
   throw new Error(
-    "@e2b/sdk is not installed. Install it with `pnpm add @e2b/sdk -w` and set " +
-      "E2B_API_KEY to use the microVM sandbox tier."
+    "@e2b/sdk is not installed. Install it with `pnpm add @e2b/sdk -w`, then configure " +
+      "E2B Sandbox in Settings → Plugins."
   )
 }
 ```
 
-<Callout type="info">
-  AgentENV compatibility is configured through Settings → Plugins → E2B Sandbox. Set "AgentENV /
-  E2B API URL" to the AgentENV API endpoint, typically `http://127.0.0.1:8000` for a local server.
-  The SDK bridge also accepts process env fallbacks: `E2B_DOMAIN` first, then AgentENV's documented
-  `E2B_API_URL`. Leave the URL empty to use E2B Cloud.
+<Callout type="warn">
+  AgentENV requires a Linux 6.8+ host with `/dev/kvm`; `127.0.0.1:8000` works only when Cognia
+  runs on that same host and network namespace. For a remote AgentENV host, use its reachable IP
+  address or domain. Follow the [AgentENV single-node quick
+  start](https://github.com/kvcache-ai/AgentENV#-quick-start-single-node) to install and start the
+  server. AgentENV currently has no built-in authorization, so keep it on a trusted network or put
+  it behind an authenticated proxy.
 </Callout>
+
+For the frontend workspace/T4 bridge, open Settings → Plugins → E2B Sandbox and set "AgentENV /
+E2B API URL" to the reachable endpoint; leave it empty to use E2B Cloud. To use the MCP server,
+separately open Settings → MCP Servers, configure the E2B preset, and attach it to the current
+character. The preset passes its own `E2B_API_KEY` and `E2B_API_URL` values to the spawned process.
+The workspace/T4 bridge reads the plugin settings and maps the URL to the SDK's `domain` option; it
+does not read host process environment variables or reuse the MCP preset values.
 
 ## The e2b workspace backend — `workspace-backend.ts`
 
-The same plugin also implements `E2BWorkspaceBackend` for the GitHub-delivery Issue→PR loop. When a
-workflow sets `worktreeMode: "e2b"`, the AI loop runs inside a fresh Firecracker microVM instead of
-the host filesystem. Each `clone()` provisions a sandbox and clones into `/tmp/cognia/<repo>/<stamp>`;
-`commitAndPush()` runs `git add/commit/push` inside the sandbox.
+The same plugin also implements `E2BWorkspaceBackend` for Marketplace integrations. When an
+integration selects `worktreeMode: "e2b"`, its AI loop runs inside a fresh Firecracker microVM
+instead of the host filesystem. Each `clone()` provisions a sandbox and clones into
+`/tmp/cognia/<repo>/<stamp>`; `commitAndPush()` runs `git add/commit/push` inside the sandbox.
 
 ```ts title="plugins/e2b-sandbox/src/workspace-backend.ts:74-90 (clone)"
 const stamp = this.opts.now().toString(36)
@@ -130,9 +139,8 @@ await execChecked(sandbox, {
 ```
 
 <Callout type="info">
-  The workspace backend and T4 exec share the same connection resolution: plugin config first,
-  then process env `E2B_API_KEY`, `E2B_DOMAIN` / `E2B_API_URL`. The default factory dynamically
-  imports `@e2b/sdk` and calls `Sandbox.create`.
+  The workspace backend and T4 exec share the same live plugin-configuration resolver. The default
+  factory dynamically imports `@e2b/sdk` and calls `Sandbox.create`.
 </Callout>
 
 ## The web code-execution stub — `lib/sandbox/web`

--- a/docs/content/docs/en/subsystems/sandbox/microvm-and-web.mdx
+++ b/docs/content/docs/en/subsystems/sandbox/microvm-and-web.mdx
@@ -12,9 +12,10 @@ description: "The T4 e2b Firecracker microVM tier, the per-session tier router i
   tier (T4): a per-session **active tier** map and a registry holding the **microVM exec
   implementation**. The `cognia-e2b-sandbox` plugin registers a real exec on activate
   (`buildMicrovmExec`); the same plugin also provides an `E2BWorkspaceBackend` for the
-  GitHub-delivery Issue→PR loop. `lib/sandbox/web/index.ts` is a deliberate **stub** — the web
-  code-execution runtime is not shipped. `types/system/sandbox.ts` carries the cross-boundary result
-  and consumption-metadata shapes.
+  GitHub-delivery Issue→PR loop. E2B-compatible self-hosted endpoints such as AgentENV can be
+  configured in that plugin's settings via the API URL field. `lib/sandbox/web/index.ts` is a
+  deliberate **stub** — the web code-execution runtime is not shipped. `types/system/sandbox.ts`
+  carries the cross-boundary result and consumption-metadata shapes.
 </TLDR>
 
 ## The tier router — `microvm-bridge.ts`
@@ -65,7 +66,7 @@ runs the argv joined through `bash -c` (so quoting matches the OS backend), then
 ```ts title="plugins/e2b-sandbox/src/microvm-exec.ts:44-76 (excerpt)"
 return async function microvmExec(payload: MicrovmExecPayload): Promise<MicrovmResult> {
   const started = now()
-  const sandbox = await factory({ apiKey: opts.apiKey ?? process.env.E2B_API_KEY })
+  const sandbox = await factory(resolveSandboxConnection(opts))
   try {
     const cmd = buildBashCommand(payload)
     const result = await sandbox.exec({
@@ -103,6 +104,13 @@ try {
 }
 ```
 
+<Callout type="info">
+  AgentENV compatibility is configured through Settings → Plugins → E2B Sandbox. Set "AgentENV /
+  E2B API URL" to the AgentENV API endpoint, typically `http://127.0.0.1:8000` for a local server.
+  The SDK bridge also accepts process env fallbacks: `E2B_DOMAIN` first, then AgentENV's documented
+  `E2B_API_URL`. Leave the URL empty to use E2B Cloud.
+</Callout>
+
 ## The e2b workspace backend — `workspace-backend.ts`
 
 The same plugin also implements `E2BWorkspaceBackend` for the GitHub-delivery Issue→PR loop. When a
@@ -121,12 +129,10 @@ await execChecked(sandbox, {
 })
 ```
 
-<Callout type="warn">
-  The workspace backend's **default** `sandboxFactory` is not wired to the SDK — it throws
-  "Default E2B sandboxFactory hasn't been wired to the SDK yet — pass `sandboxFactory` explicitly"
-  (`workspace-backend.ts:187-191`). Callers must inject a factory via plugin settings. The
-  `microvm-exec.ts` factory (used for the T4 tier) **is** wired to `Sandbox.create`; these are two
-  separate factories with different completeness.
+<Callout type="info">
+  The workspace backend and T4 exec share the same connection resolution: plugin config first,
+  then process env `E2B_API_KEY`, `E2B_DOMAIN` / `E2B_API_URL`. The default factory dynamically
+  imports `@e2b/sdk` and calls `Sandbox.create`.
 </Callout>
 
 ## The web code-execution stub — `lib/sandbox/web`

--- a/docs/content/docs/zh/subsystems/sandbox/microvm-and-web.mdx
+++ b/docs/content/docs/zh/subsystems/sandbox/microvm-and-web.mdx
@@ -1,6 +1,6 @@
 ---
 title: "microVM 与 Web"
-description: "T4 级 e2b Firecracker microVM 层、microvm-bridge 中的会话级层路由器、为 GitHub-delivery 闭环服务的 e2b 工作区后端、Web 代码执行 stub，以及 SandboxExecutionResult / 消耗元数据类型。"
+description: "T4 级 e2b Firecracker microVM 层、microvm-bridge 中的会话级层路由器、为 Marketplace integration 服务的 e2b 工作区后端、Web 代码执行 stub，以及 SandboxExecutionResult / 消耗元数据类型。"
 ---
 
 # microVM 与 Web
@@ -10,7 +10,7 @@ description: "T4 级 e2b Firecracker microVM 层、microvm-bridge 中的会话�
 <TLDR>
   `lib/sandbox/microvm-bridge.ts` 是 OS 沙箱与 e2b microVM 层（T4）之间由两部分组成的胶水层：一个会话级
   **active tier** 映射，以及一个持有 **microVM exec 实现** 的注册表。`cognia-e2b-sandbox` 插件在
-  activate 时注册真实的 exec（`buildMicrovmExec`）；同一个插件还为 GitHub-delivery 的 Issue→PR 闭环提供
+  activate 时注册真实的 exec（`buildMicrovmExec`）；同一个插件还为 Marketplace integration 提供
   `E2BWorkspaceBackend`。AgentENV 这类 E2B-compatible 自托管 endpoint 可在该插件设置里通过 API URL 配置。
   `lib/sandbox/web/index.ts` 是一个刻意保留的 **stub** —— Web 代码执行运行时尚未发布。`types/system/sandbox.ts`
   承载跨边界的结果与消耗元数据形状。
@@ -84,11 +84,18 @@ return async function microvmExec(payload: MicrovmExecPayload): Promise<MicrovmR
 }
 ```
 
-<Callout type="info">
-  AgentENV 兼容配置在 Settings → Plugins → E2B Sandbox 中完成。将 “AgentENV / E2B API URL”
-  设为 AgentENV API endpoint；本地默认通常是 `http://127.0.0.1:8000`。SDK bridge 也接受进程环境变量
-  fallback：优先 `E2B_DOMAIN`，其次是 AgentENV 文档里的 `E2B_API_URL`。留空则使用 E2B Cloud。
+<Callout type="warn">
+  AgentENV 需要 Linux 6.8+ 与 `/dev/kvm`；只有当 Cognia 与 AgentENV 运行在同一台主机、同一网络命名空间时，
+  `127.0.0.1:8000` 才有效。AgentENV 位于远程主机时，请使用该主机可访问的 IP 地址或域名。请按照
+  [AgentENV 单节点快速开始](https://github.com/kvcache-ai/AgentENV#-quick-start-single-node)
+  安装并启动服务。AgentENV 当前没有内置鉴权，因此只能部署在可信网络中，或置于带身份验证的代理之后。
 </Callout>
+
+使用前端 workspace/T4 bridge 时，请打开 Settings → Plugins → E2B Sandbox，将 “AgentENV / E2B API
+URL” 设置为可访问的 endpoint；留空则使用 E2B Cloud。使用 MCP server 时，需要另外打开 Settings → MCP
+Servers，配置 E2B preset 并将其附加到当前 character。该 preset 会把自己配置的 `E2B_API_KEY` 与
+`E2B_API_URL` 传给子进程。workspace/T4 bridge 读取插件设置，并把 URL 映射为 SDK 的 `domain` 参数；
+它不会读取宿主进程环境变量，也不会复用 MCP preset 的配置值。
 
 `buildBashCommand`（`microvm-exec.ts:84-92`）以内联方式导出环境变量，并通过 `<<<` 管道传入 stdin，环境变量
 名与值均经过 shell 转义。默认 factory 会动态导入 `@e2b/sdk` 并调用 `Sandbox.create`，当 SDK 缺失时给出
@@ -101,15 +108,15 @@ try {
   )) as { Sandbox?: unknown }
 } catch {
   throw new Error(
-    "@e2b/sdk is not installed. Install it with `pnpm add @e2b/sdk -w` and set " +
-      "E2B_API_KEY to use the microVM sandbox tier."
+    "@e2b/sdk is not installed. Install it with `pnpm add @e2b/sdk -w`, then configure " +
+      "E2B Sandbox in Settings → Plugins."
   )
 }
 ```
 
 ## e2b 工作区后端 —— `workspace-backend.ts`
 
-同一个插件还为 GitHub-delivery 的 Issue→PR 闭环实现了 `E2BWorkspaceBackend`。当某个工作流设置
+同一个插件还为 Marketplace integration 实现了 `E2BWorkspaceBackend`。当某个 integration 选择
 `worktreeMode: "e2b"` 时，AI 闭环会在一个全新的 Firecracker microVM 内运行，而不是在宿主文件系统上运行。
 每次 `clone()` 都会预置一个沙箱，并克隆到 `/tmp/cognia/<repo>/<stamp>`；`commitAndPush()` 则在沙箱内运行
 `git add/commit/push`。
@@ -126,8 +133,8 @@ await execChecked(sandbox, {
 ```
 
 <Callout type="info">
-  工作区后端与 T4 exec 使用同一套连接解析：插件配置优先，其次是进程环境变量 `E2B_API_KEY`、
-  `E2B_DOMAIN` / `E2B_API_URL`。默认 factory 会动态导入 `@e2b/sdk` 并调用 `Sandbox.create`。
+  工作区后端与 T4 exec 使用同一个实时插件配置解析器。默认 factory 会动态导入 `@e2b/sdk`
+  并调用 `Sandbox.create`。
 </Callout>
 
 ## Web 代码执行 stub —— `lib/sandbox/web`

--- a/docs/content/docs/zh/subsystems/sandbox/microvm-and-web.mdx
+++ b/docs/content/docs/zh/subsystems/sandbox/microvm-and-web.mdx
@@ -11,8 +11,9 @@ description: "T4 级 e2b Firecracker microVM 层、microvm-bridge 中的会话�
   `lib/sandbox/microvm-bridge.ts` 是 OS 沙箱与 e2b microVM 层（T4）之间由两部分组成的胶水层：一个会话级
   **active tier** 映射，以及一个持有 **microVM exec 实现** 的注册表。`cognia-e2b-sandbox` 插件在
   activate 时注册真实的 exec（`buildMicrovmExec`）；同一个插件还为 GitHub-delivery 的 Issue→PR 闭环提供
-  `E2BWorkspaceBackend`。`lib/sandbox/web/index.ts` 是一个刻意保留的 **stub** —— Web 代码执行运行时尚未发布。
-  `types/system/sandbox.ts` 承载跨边界的结果与消耗元数据形状。
+  `E2BWorkspaceBackend`。AgentENV 这类 E2B-compatible 自托管 endpoint 可在该插件设置里通过 API URL 配置。
+  `lib/sandbox/web/index.ts` 是一个刻意保留的 **stub** —— Web 代码执行运行时尚未发布。`types/system/sandbox.ts`
+  承载跨边界的结果与消耗元数据形状。
 </TLDR>
 
 ## 层路由器 —— `microvm-bridge.ts`
@@ -63,7 +64,7 @@ export type MicrovmExec = (payload: MicrovmExecPayload) => Promise<MicrovmResult
 ```ts title="plugins/e2b-sandbox/src/microvm-exec.ts:44-76 (excerpt)"
 return async function microvmExec(payload: MicrovmExecPayload): Promise<MicrovmResult> {
   const started = now()
-  const sandbox = await factory({ apiKey: opts.apiKey ?? process.env.E2B_API_KEY })
+  const sandbox = await factory(resolveSandboxConnection(opts))
   try {
     const cmd = buildBashCommand(payload)
     const result = await sandbox.exec({
@@ -82,6 +83,12 @@ return async function microvmExec(payload: MicrovmExecPayload): Promise<MicrovmR
   }
 }
 ```
+
+<Callout type="info">
+  AgentENV 兼容配置在 Settings → Plugins → E2B Sandbox 中完成。将 “AgentENV / E2B API URL”
+  设为 AgentENV API endpoint；本地默认通常是 `http://127.0.0.1:8000`。SDK bridge 也接受进程环境变量
+  fallback：优先 `E2B_DOMAIN`，其次是 AgentENV 文档里的 `E2B_API_URL`。留空则使用 E2B Cloud。
+</Callout>
 
 `buildBashCommand`（`microvm-exec.ts:84-92`）以内联方式导出环境变量，并通过 `<<<` 管道传入 stdin，环境变量
 名与值均经过 shell 转义。默认 factory 会动态导入 `@e2b/sdk` 并调用 `Sandbox.create`，当 SDK 缺失时给出
@@ -118,11 +125,9 @@ await execChecked(sandbox, {
 })
 ```
 
-<Callout type="warn">
-  工作区后端的 **默认** `sandboxFactory` 并未接入 SDK —— 它会抛出
-  "Default E2B sandboxFactory hasn't been wired to the SDK yet — pass `sandboxFactory` explicitly"
-  （`workspace-backend.ts:187-191`）。调用方必须通过插件设置注入一个 factory。`microvm-exec.ts` 的
-  factory（用于 T4 层）**确实**已接入 `Sandbox.create`；这是两个完成度不同的独立 factory。
+<Callout type="info">
+  工作区后端与 T4 exec 使用同一套连接解析：插件配置优先，其次是进程环境变量 `E2B_API_KEY`、
+  `E2B_DOMAIN` / `E2B_API_URL`。默认 factory 会动态导入 `@e2b/sdk` 并调用 `Sandbox.create`。
 </Callout>
 
 ## Web 代码执行 stub —— `lib/sandbox/web`

--- a/plugins/e2b-sandbox/plugin.json
+++ b/plugins/e2b-sandbox/plugin.json
@@ -33,7 +33,7 @@
     "apiKey": "",
     "apiUrl": ""
   },
-  "activationEvents": ["startup"],
+  "activationEvents": ["startup", "onCommand:sandbox"],
   "runtimeCompatibility": {
     "browser": {
       "availability": "blocked",
@@ -47,5 +47,13 @@
       "availability": "blocked",
       "reason": "Spawns @e2b/mcp-server via npx — unavailable on mobile."
     }
-  }
+  },
+  "commands": [
+    {
+      "id": "sandbox",
+      "name": "/sandbox",
+      "description": "Attach the E2B sandbox MCP to the current character.",
+      "icon": "Box"
+    }
+  ]
 }

--- a/plugins/e2b-sandbox/plugin.json
+++ b/plugins/e2b-sandbox/plugin.json
@@ -2,9 +2,9 @@
   "id": "cognia-e2b-sandbox",
   "name": "E2B Sandbox",
   "version": "0.1.0",
-  "description": "Run code in ephemeral Firecracker microVM sandboxes via E2B \u2014 useful for safe Computer Use isolation, code interpretation, and untrusted execution.",
+  "description": "Run code in ephemeral Firecracker microVM sandboxes via E2B — useful for safe Computer Use isolation, code interpretation, and untrusted execution.",
   "type": "frontend",
-  "capabilities": ["mcp-server-preset", "commands"],
+  "capabilities": ["mcp-server-preset", "commands", "configuration"],
   "main": "src/index.ts",
   "author": "cognia-next",
   "license": "MIT",
@@ -13,11 +13,31 @@
     "cognia": ">=0.1.0"
   },
   "permissions": [],
-  "activationEvents": ["startup", "onCommand:sandbox"],
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "secret": true,
+        "title": "E2B / AgentENV API key",
+        "description": "Required for E2B Cloud; optional for local AgentENV if auth is disabled."
+      },
+      "apiUrl": {
+        "type": "string",
+        "title": "AgentENV / E2B API URL",
+        "description": "Set this to your AgentENV server URL, for example http://127.0.0.1:8000."
+      }
+    }
+  },
+  "defaultConfig": {
+    "apiKey": "",
+    "apiUrl": ""
+  },
+  "activationEvents": ["startup"],
   "runtimeCompatibility": {
     "browser": {
       "availability": "blocked",
-      "reason": "Requires npx to spawn @e2b/mcp-server \u2014 desktop only."
+      "reason": "Requires npx to spawn @e2b/mcp-server — desktop only."
     },
     "tauri": {
       "availability": "supported",
@@ -25,15 +45,7 @@
     },
     "mobile": {
       "availability": "blocked",
-      "reason": "Spawns @e2b/mcp-server via npx \u2014 unavailable on mobile."
+      "reason": "Spawns @e2b/mcp-server via npx — unavailable on mobile."
     }
-  },
-  "commands": [
-    {
-      "id": "sandbox",
-      "name": "/sandbox",
-      "description": "Attach the E2B sandbox MCP to the current character.",
-      "icon": "Box"
-    }
-  ]
+  }
 }

--- a/plugins/e2b-sandbox/src/index.test.ts
+++ b/plugins/e2b-sandbox/src/index.test.ts
@@ -1,10 +1,5 @@
 import type { PluginContext } from "@/types/plugin"
 
-jest.mock("@/lib/slash-commands/registry", () => ({
-  registerSlashCommand: jest.fn(),
-  unregisterCommandsByPlugin: jest.fn(),
-}))
-
 jest.mock("@/lib/github/workspace", () => ({ setE2BBackend: jest.fn() }))
 jest.mock("@/lib/sandbox/microvm-bridge", () => ({ setMicrovmExec: jest.fn() }))
 
@@ -16,15 +11,12 @@ jest.mock("./workspace-backend", () => ({
 const fakeExec = { kind: "microvm-exec" }
 jest.mock("./microvm-exec", () => ({ buildMicrovmExec: jest.fn(() => fakeExec) }))
 
-import { registerSlashCommand, unregisterCommandsByPlugin } from "@/lib/slash-commands/registry"
 import { setE2BBackend } from "@/lib/github/workspace"
 import { setMicrovmExec } from "@/lib/sandbox/microvm-bridge"
 import { E2BWorkspaceBackend } from "./workspace-backend"
 import { buildMicrovmExec } from "./microvm-exec"
 import e2bSandbox from "./index"
 
-const registerMock = registerSlashCommand as jest.Mock
-const unregisterMock = unregisterCommandsByPlugin as jest.Mock
 const setE2BBackendMock = setE2BBackend as jest.Mock
 const setMicrovmExecMock = setMicrovmExec as jest.Mock
 const E2BWorkspaceBackendMock = E2BWorkspaceBackend as jest.Mock
@@ -34,19 +26,16 @@ function makeCtx(opts: { workspace?: boolean; config?: Record<string, unknown> }
   const presets: Array<{ id: string }> = []
   const unregister = jest.fn()
   const registerBackend = jest.fn(() => ({ unregister }))
-  let config = opts.config ?? {}
-  let configListener: ((next: Record<string, unknown>) => void) | undefined
-  const configUnsubscribe = jest.fn(() => {
-    configListener = undefined
-  })
+  const showToast = jest.fn()
+  const config = opts.config ?? {}
+  const configUnsubscribe = jest.fn()
   const ctx: Partial<PluginContext> = {
     pluginId: "cognia-e2b-sandbox",
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } as never,
     config,
     configuration: {
       getAll: () => config,
-      onChange: (listener: (next: Record<string, unknown>) => void) => {
-        configListener = listener
+      onChange: (_listener: (next: Record<string, unknown>) => void) => {
         return configUnsubscribe
       },
     } as never,
@@ -55,6 +44,7 @@ function makeCtx(opts: { workspace?: boolean; config?: Record<string, unknown> }
         presets.push(preset)
       },
     } as never,
+    ui: { showToast } as never,
     workspace: opts.workspace ? ({ registerBackend } as never) : undefined,
   }
   return {
@@ -62,17 +52,12 @@ function makeCtx(opts: { workspace?: boolean; config?: Record<string, unknown> }
     presets,
     registerBackend,
     unregister,
+    showToast,
     configUnsubscribe,
-    emitConfigChange: (next: Record<string, unknown>) => {
-      config = next
-      configListener?.(next)
-    },
   }
 }
 
 beforeEach(() => {
-  registerMock.mockReset()
-  unregisterMock.mockReset()
   setE2BBackendMock.mockReset()
   setMicrovmExecMock.mockReset()
   E2BWorkspaceBackendMock.mockClear()
@@ -83,6 +68,8 @@ describe("e2b-sandbox (built-in)", () => {
   it("declares plugin config and exposes AgentENV's API URL in the MCP preset", () => {
     const manifest = e2bSandbox.manifest as unknown as {
       capabilities: string[]
+      activationEvents: string[]
+      commands: Array<{ id: string; name: string }>
       configSchema?: { properties?: Record<string, unknown> }
       mcpServerPresets: Array<{
         id: string
@@ -91,6 +78,8 @@ describe("e2b-sandbox (built-in)", () => {
       }>
     }
     expect(manifest.capabilities).toContain("configuration")
+    expect(manifest.activationEvents).toContain("onCommand:sandbox")
+    expect(manifest.commands).toContainEqual(expect.objectContaining({ id: "sandbox" }))
     expect(manifest.configSchema?.properties).toHaveProperty("apiUrl")
     const preset = manifest.mcpServerPresets[0]
     expect(preset.id).toBe("e2b-sandbox")
@@ -100,18 +89,20 @@ describe("e2b-sandbox (built-in)", () => {
     expect(byKey.E2B_API_URL).toMatchObject({ placement: "env" })
   })
 
-  it("activate registers the e2b MCP preset and the /sandbox slash command", async () => {
-    const { ctx, presets } = makeCtx({ workspace: true })
-    await e2bSandbox.activate?.(ctx)
+  it("activate registers the e2b MCP preset and handles the managed /sandbox command", async () => {
+    const { ctx, presets, showToast } = makeCtx({ workspace: true })
+    const hooks = await e2bSandbox.activate?.(ctx)
     expect(presets).toEqual([expect.objectContaining({ id: "e2b-sandbox" })])
-    expect(registerMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "e2b.attach",
-        name: "/sandbox",
-        source: "plugin",
-        pluginId: "cognia-e2b-sandbox",
-      })
+    await expect(hooks?.onCommand?.("sandbox", [])).resolves.toBe(true)
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining("Settings → Plugins → E2B Sandbox"),
+      "info"
     )
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining("Settings → MCP Servers"),
+      "info"
+    )
+    await expect(hooks?.onCommand?.("other", [])).resolves.toBe(false)
     await e2bSandbox.deactivate?.(ctx)
   })
 
@@ -141,40 +132,6 @@ describe("e2b-sandbox (built-in)", () => {
     expect(setMicrovmExecMock).toHaveBeenCalledWith(fakeExec)
     await e2bSandbox.deactivate?.(ctx)
     expect(setMicrovmExecMock).toHaveBeenLastCalledWith(null)
-  })
-
-  it("threads plugin config into the SDK connection resolver and tracks config changes", async () => {
-    const { ctx, emitConfigChange } = makeCtx({
-      workspace: true,
-      config: { apiKey: "key-1", apiUrl: "http://127.0.0.1:8000" },
-    })
-    await e2bSandbox.activate?.(ctx)
-    const backendOptions = E2BWorkspaceBackendMock.mock.calls[0][0] as {
-      connection: () => unknown
-    }
-    const execOptions = buildMicrovmExecMock.mock.calls[0][0] as { connection: () => unknown }
-    expect(backendOptions.connection()).toEqual({
-      apiKey: "key-1",
-      domain: "http://127.0.0.1:8000",
-    })
-    expect(execOptions.connection()).toEqual({
-      apiKey: "key-1",
-      domain: "http://127.0.0.1:8000",
-    })
-
-    emitConfigChange({ apiKey: "key-2", apiUrl: "http://agentenv.local:8000" })
-    expect(backendOptions.connection()).toEqual({
-      apiKey: "key-2",
-      domain: "http://agentenv.local:8000",
-    })
-    await e2bSandbox.deactivate?.(ctx)
-  })
-
-  it("deactivate unregisters the plugin's commands", async () => {
-    const { ctx } = makeCtx({ workspace: true })
-    await e2bSandbox.activate?.(ctx)
-    await e2bSandbox.deactivate?.(ctx)
-    expect(unregisterMock).toHaveBeenCalledWith("cognia-e2b-sandbox")
   })
 
   it("deactivate unsubscribes from plugin config changes", async () => {

--- a/plugins/e2b-sandbox/src/index.test.ts
+++ b/plugins/e2b-sandbox/src/index.test.ts
@@ -19,20 +19,37 @@ jest.mock("./microvm-exec", () => ({ buildMicrovmExec: jest.fn(() => fakeExec) }
 import { registerSlashCommand, unregisterCommandsByPlugin } from "@/lib/slash-commands/registry"
 import { setE2BBackend } from "@/lib/github/workspace"
 import { setMicrovmExec } from "@/lib/sandbox/microvm-bridge"
+import { E2BWorkspaceBackend } from "./workspace-backend"
+import { buildMicrovmExec } from "./microvm-exec"
 import e2bSandbox from "./index"
 
 const registerMock = registerSlashCommand as jest.Mock
 const unregisterMock = unregisterCommandsByPlugin as jest.Mock
 const setE2BBackendMock = setE2BBackend as jest.Mock
 const setMicrovmExecMock = setMicrovmExec as jest.Mock
+const E2BWorkspaceBackendMock = E2BWorkspaceBackend as jest.Mock
+const buildMicrovmExecMock = buildMicrovmExec as jest.Mock
 
-function makeCtx(opts: { workspace?: boolean } = {}) {
+function makeCtx(opts: { workspace?: boolean; config?: Record<string, unknown> } = {}) {
   const presets: Array<{ id: string }> = []
   const unregister = jest.fn()
   const registerBackend = jest.fn(() => ({ unregister }))
+  let config = opts.config ?? {}
+  let configListener: ((next: Record<string, unknown>) => void) | undefined
+  const configUnsubscribe = jest.fn(() => {
+    configListener = undefined
+  })
   const ctx: Partial<PluginContext> = {
     pluginId: "cognia-e2b-sandbox",
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } as never,
+    config,
+    configuration: {
+      getAll: () => config,
+      onChange: (listener: (next: Record<string, unknown>) => void) => {
+        configListener = listener
+        return configUnsubscribe
+      },
+    } as never,
     agent: {
       registerMcpServerPreset: (preset: { id: string }) => {
         presets.push(preset)
@@ -40,7 +57,17 @@ function makeCtx(opts: { workspace?: boolean } = {}) {
     } as never,
     workspace: opts.workspace ? ({ registerBackend } as never) : undefined,
   }
-  return { ctx: ctx as PluginContext, presets, registerBackend, unregister }
+  return {
+    ctx: ctx as PluginContext,
+    presets,
+    registerBackend,
+    unregister,
+    configUnsubscribe,
+    emitConfigChange: (next: Record<string, unknown>) => {
+      config = next
+      configListener?.(next)
+    },
+  }
 }
 
 beforeEach(() => {
@@ -48,16 +75,43 @@ beforeEach(() => {
   unregisterMock.mockReset()
   setE2BBackendMock.mockReset()
   setMicrovmExecMock.mockReset()
+  E2BWorkspaceBackendMock.mockClear()
+  buildMicrovmExecMock.mockClear()
 })
 
 describe("e2b-sandbox (built-in)", () => {
-  it("activate registers the e2b MCP preset and declares its slash command", async () => {
+  it("declares plugin config and exposes AgentENV's API URL in the MCP preset", () => {
+    const manifest = e2bSandbox.manifest as unknown as {
+      capabilities: string[]
+      configSchema?: { properties?: Record<string, unknown> }
+      mcpServerPresets: Array<{
+        id: string
+        config: { env?: Record<string, string> }
+        fields: Array<{ key: string; placement: string; secret?: boolean }>
+      }>
+    }
+    expect(manifest.capabilities).toContain("configuration")
+    expect(manifest.configSchema?.properties).toHaveProperty("apiUrl")
+    const preset = manifest.mcpServerPresets[0]
+    expect(preset.id).toBe("e2b-sandbox")
+    expect(preset.config.env).toHaveProperty("E2B_API_URL")
+    const byKey = Object.fromEntries(preset.fields.map((f) => [f.key, f]))
+    expect(byKey.E2B_API_KEY).toMatchObject({ placement: "env", secret: true })
+    expect(byKey.E2B_API_URL).toMatchObject({ placement: "env" })
+  })
+
+  it("activate registers the e2b MCP preset and the /sandbox slash command", async () => {
     const { ctx, presets } = makeCtx({ workspace: true })
     await e2bSandbox.activate?.(ctx)
     expect(presets).toEqual([expect.objectContaining({ id: "e2b-sandbox" })])
-    // The slash command is manifest-declared now; the plugin must not touch
-    // the registry itself.
-    expect(registerMock).not.toHaveBeenCalled()
+    expect(registerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "e2b.attach",
+        name: "/sandbox",
+        source: "plugin",
+        pluginId: "cognia-e2b-sandbox",
+      })
+    )
     await e2bSandbox.deactivate?.(ctx)
   })
 
@@ -89,31 +143,44 @@ describe("e2b-sandbox (built-in)", () => {
     expect(setMicrovmExecMock).toHaveBeenLastCalledWith(null)
   })
 
-  it("declares its slash command instead of registering it imperatively", async () => {
-    const { ctx } = makeCtx()
-    const hooks = await e2bSandbox.activate?.(ctx)
-    // The manager owns registration for manifest-declared commands; a plugin
-    // touching the registry itself skips namespacing, conflict detection,
-    // aliases, the command-palette entry and teardown.
-    expect(registerMock).not.toHaveBeenCalled()
-    expect(typeof hooks?.onCommand).toBe("function")
-    const commands = (e2bSandbox.manifest as { commands?: Array<{ id: string }> }).commands
-    expect(commands?.map((c) => c.id)).toEqual(["sandbox"])
+  it("threads plugin config into the SDK connection resolver and tracks config changes", async () => {
+    const { ctx, emitConfigChange } = makeCtx({
+      workspace: true,
+      config: { apiKey: "key-1", apiUrl: "http://127.0.0.1:8000" },
+    })
+    await e2bSandbox.activate?.(ctx)
+    const backendOptions = E2BWorkspaceBackendMock.mock.calls[0][0] as {
+      connection: () => unknown
+    }
+    const execOptions = buildMicrovmExecMock.mock.calls[0][0] as { connection: () => unknown }
+    expect(backendOptions.connection()).toEqual({
+      apiKey: "key-1",
+      domain: "http://127.0.0.1:8000",
+    })
+    expect(execOptions.connection()).toEqual({
+      apiKey: "key-1",
+      domain: "http://127.0.0.1:8000",
+    })
+
+    emitConfigChange({ apiKey: "key-2", apiUrl: "http://agentenv.local:8000" })
+    expect(backendOptions.connection()).toEqual({
+      apiKey: "key-2",
+      domain: "http://agentenv.local:8000",
+    })
+    await e2bSandbox.deactivate?.(ctx)
   })
 
-  it("handles its own command and declines others", async () => {
-    const { ctx } = makeCtx()
-    const showToast = jest.fn()
-    ;(ctx as { ui?: unknown }).ui = { showToast }
-    const hooks = await e2bSandbox.activate?.(ctx)
-    expect(await hooks?.onCommand?.("not-mine", [])).toBe(false)
-    expect(showToast).not.toHaveBeenCalled()
-    expect(await hooks?.onCommand?.("sandbox", [])).toBe(true)
-    expect(showToast).toHaveBeenCalled()
+  it("deactivate unregisters the plugin's commands", async () => {
+    const { ctx } = makeCtx({ workspace: true })
+    await e2bSandbox.activate?.(ctx)
+    await e2bSandbox.deactivate?.(ctx)
+    expect(unregisterMock).toHaveBeenCalledWith("cognia-e2b-sandbox")
   })
 
-  it("declares lazy activation for its command", () => {
-    const events = (e2bSandbox.manifest as { activationEvents?: string[] }).activationEvents
-    expect(events).toContain("onCommand:sandbox")
+  it("deactivate unsubscribes from plugin config changes", async () => {
+    const { ctx, configUnsubscribe } = makeCtx({ workspace: true })
+    await e2bSandbox.activate?.(ctx)
+    await e2bSandbox.deactivate?.(ctx)
+    expect(configUnsubscribe).toHaveBeenCalledTimes(1)
   })
 })

--- a/plugins/e2b-sandbox/src/index.ts
+++ b/plugins/e2b-sandbox/src/index.ts
@@ -15,9 +15,10 @@
  * Part of M3 of the plugin-first Computer Use plan.
  */
 
-import type { PluginContext, PluginDefinition } from "@/types/plugin"
-import { defineMcpServerPreset } from "@cognia/plugin-sdk"
-import { registerSlashCommand, unregisterCommandsByPlugin } from "@/lib/slash-commands/registry"
+import type { PluginContext } from "@/types/plugin"
+import { defineMcpServerPreset, definePlugin } from "@cognia/plugin-sdk"
+import type { PluginManifest } from "@cognia/plugin-sdk/manifest"
+import manifestJson from "../plugin.json"
 // `setE2BBackend` kept as a fallback for hosts that don't expose
 // `ctx.workspace` yet (older bootstrap paths / unit-test contexts). When
 // the new API is present, we register through it for ADR-0026 §2 §D
@@ -88,33 +89,57 @@ function updateSandboxConnection(config: Record<string, unknown> | undefined): v
   sandboxConnection = connectionFromConfig(config)
 }
 
-const definition: PluginDefinition = {
-  manifest: {
-    id: "cognia-e2b-sandbox",
-    name: "E2B Sandbox",
-    version: "0.1.0",
-    type: "frontend",
-    capabilities: ["mcp-server-preset", "commands", "configuration"],
-    main: "src/index.ts",
-    configSchema: {
-      type: "object",
-      properties: {
-        apiKey: {
-          type: "string",
-          secret: true,
-          title: "E2B / AgentENV API key",
-          description: "Required for E2B Cloud; optional for local AgentENV if auth is disabled.",
-        },
-        apiUrl: {
-          type: "string",
-          title: "AgentENV / E2B API URL",
-          description: "Set this to your AgentENV server URL, for example http://127.0.0.1:8000.",
-        },
+const manifest = {
+  ...manifestJson,
+  type: "frontend",
+  author: { name: manifestJson.author },
+  capabilities: ["mcp-server-preset", "commands", "configuration"],
+  configSchema: {
+    ...manifestJson.configSchema,
+    type: "object",
+    properties: {
+      apiKey: {
+        ...manifestJson.configSchema.properties.apiKey,
+        type: "string",
+      },
+      apiUrl: {
+        ...manifestJson.configSchema.properties.apiUrl,
+        type: "string",
       },
     },
-    defaultConfig: { apiKey: "", apiUrl: "" },
-    mcpServerPresets: [E2B_PRESET],
-  } as never,
+  },
+  activationEvents: ["startup", "onCommand:sandbox"],
+  runtimeCompatibility: {
+    browser: {
+      availability: "blocked",
+      reason: manifestJson.runtimeCompatibility.browser.reason,
+    },
+    tauri: {
+      availability: "supported",
+      entrypoint: manifestJson.runtimeCompatibility.tauri.entrypoint,
+    },
+    mobile: {
+      availability: "blocked",
+      reason: manifestJson.runtimeCompatibility.mobile.reason,
+    },
+  },
+  commands: [
+    {
+      id: "sandbox",
+      name: "/sandbox",
+      description: manifestJson.commands[0].description,
+      icon: "Box",
+    },
+  ],
+  mcpServerPresets: [E2B_PRESET],
+} satisfies PluginManifest
+
+const definition = definePlugin({
+  // Spread plugin.json: `builtinManifest()` merges module-over-JSON, so a
+  // hand-written subset here would win and silently drop manifest fields.
+  // Literal discriminants above preserve compile-time contribution checking
+  // despite TypeScript widening values imported from JSON.
+  manifest,
   activate: async (ctx: PluginContext) => {
     ctx.logger?.info("e2b-sandbox plugin activated")
     configChangeDispose?.()
@@ -125,11 +150,10 @@ const definition: PluginDefinition = {
 
     ctx.agent?.registerMcpServerPreset?.(E2B_PRESET)
 
-    // Register the cloud-sandbox workspace backend so GitHub Delivery's
-    // Issue → PR loop can opt in via `worktreeMode: "e2b"`. The backend
-    // lazy-loads `@e2b/sdk`; if the SDK isn't installed it surfaces a
-    // helpful install hint at the first clone attempt instead of failing
-    // here at activation time.
+    // Register the cloud-sandbox workspace backend for Marketplace
+    // integrations that select `worktreeMode: "e2b"`. The backend lazy-loads
+    // `@e2b/sdk`; if the SDK isn't installed it surfaces a helpful install
+    // hint at the first clone attempt instead of failing at activation time.
     //
     // Prefer ADR-0026 §2 §D `ctx.workspace.registerBackend(...)` when
     // available so the registration carries the plugin id + auto-cleanup
@@ -153,26 +177,27 @@ const definition: PluginDefinition = {
       workspaceRegistrationDispose = () => setE2BBackend(null)
     }
 
-    registerSlashCommand({
-      id: "e2b.attach",
-      name: "/sandbox",
-      description: "Attach the E2B sandbox MCP to the current character.",
-      handler: () => ({
-        message:
-          "Open Settings → MCP Servers, click E2B Sandbox in the gallery, paste your E2B API key, then attach it to the current character.",
-      }),
-      source: "plugin",
-      pluginId: ctx.pluginId,
-    })
-
     // ADR-0028 / T4 — register the microvm exec adapter so any session
     // with `sandboxTier: "microvm"` routes `sandbox_*` tool calls through
     // an ephemeral Firecracker microVM instead of the OS sandbox. When
     // `@e2b/sdk` isn't installed the factory throws a clean install hint
     // at first call — strict-mode compliant (no silent fallback).
     setMicrovmExec(buildMicrovmExec({ connection: () => sandboxConnection }))
+
+    // The slash command is declared in plugin.json so the manager owns
+    // namespacing, command-palette registration, idle refresh, and teardown.
+    return {
+      onCommand: async (command: string) => {
+        if (command !== "sandbox") return false
+        ctx.ui?.showToast?.(
+          "Configure workspace/T4 credentials in Settings → Plugins → E2B Sandbox. Separately configure and attach the E2B preset in Settings → MCP Servers.",
+          "info"
+        )
+        return true
+      },
+    }
   },
-  deactivate: async (ctx?: PluginContext) => {
+  deactivate: async () => {
     if (configChangeDispose) {
       configChangeDispose()
       configChangeDispose = undefined
@@ -182,10 +207,7 @@ const definition: PluginDefinition = {
       workspaceRegistrationDispose = undefined
     }
     setMicrovmExec(null)
-    if (ctx?.pluginId) {
-      unregisterCommandsByPlugin(ctx.pluginId)
-    }
   },
-}
+})
 
 export default definition

--- a/plugins/e2b-sandbox/src/index.ts
+++ b/plugins/e2b-sandbox/src/index.ts
@@ -17,7 +17,7 @@
 
 import type { PluginContext, PluginDefinition } from "@/types/plugin"
 import { defineMcpServerPreset } from "@cognia/plugin-sdk"
-import manifestJson from "../plugin.json"
+import { registerSlashCommand, unregisterCommandsByPlugin } from "@/lib/slash-commands/registry"
 // `setE2BBackend` kept as a fallback for hosts that don't expose
 // `ctx.workspace` yet (older bootstrap paths / unit-test contexts). When
 // the new API is present, we register through it for ADR-0026 §2 §D
@@ -27,6 +27,7 @@ import manifestJson from "../plugin.json"
 import { setE2BBackend } from "@/lib/github/workspace"
 import { setMicrovmExec } from "@/lib/sandbox/microvm-bridge"
 import { E2BWorkspaceBackend } from "./workspace-backend"
+import type { E2BSandboxConnection } from "./workspace-backend"
 import { buildMicrovmExec } from "./microvm-exec"
 
 const E2B_PRESET = defineMcpServerPreset({
@@ -39,15 +40,22 @@ const E2B_PRESET = defineMcpServerPreset({
   config: {
     command: "npx",
     args: ["-y", "@e2b/mcp-server"],
-    env: { E2B_API_KEY: "" },
+    env: { E2B_API_KEY: "", E2B_API_URL: "" },
   },
   fields: [
     {
       key: "E2B_API_KEY",
-      label: "E2B API key",
+      label: "E2B / AgentENV API key",
       placement: "env",
       secret: true,
-      description: "Get one at e2b.dev.",
+      description: "Required for E2B Cloud; optional for local AgentENV if auth is disabled.",
+    },
+    {
+      key: "E2B_API_URL",
+      label: "AgentENV / E2B API URL",
+      placement: "env",
+      placeholder: "http://127.0.0.1:8000",
+      description: "Set this to your AgentENV server URL. Leave empty for E2B Cloud.",
     },
   ],
   runtime: "both",
@@ -60,16 +68,60 @@ const E2B_PRESET = defineMcpServerPreset({
 // explicitly rather than relying on the legacy `setE2BBackend(null)`
 // shim. Module-scoped because there's only ever one e2b plugin instance.
 let workspaceRegistrationDispose: (() => void) | undefined
+let configChangeDispose: (() => void) | undefined
+let sandboxConnection: E2BSandboxConnection = {}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function connectionFromConfig(config: Record<string, unknown> | undefined): E2BSandboxConnection {
+  const apiKey = readString(config?.apiKey)
+  const domain = readString(config?.domain) ?? readString(config?.apiUrl)
+  return {
+    ...(apiKey ? { apiKey } : {}),
+    ...(domain ? { domain } : {}),
+  }
+}
+
+function updateSandboxConnection(config: Record<string, unknown> | undefined): void {
+  sandboxConnection = connectionFromConfig(config)
+}
 
 const definition: PluginDefinition = {
-  // Spread plugin.json: `builtinManifest()` merges module-over-JSON, so a
-  // hand-written subset here would WIN and silently drop `commands[]`.
   manifest: {
-    ...(manifestJson as object),
+    id: "cognia-e2b-sandbox",
+    name: "E2B Sandbox",
+    version: "0.1.0",
+    type: "frontend",
+    capabilities: ["mcp-server-preset", "commands", "configuration"],
+    main: "src/index.ts",
+    configSchema: {
+      type: "object",
+      properties: {
+        apiKey: {
+          type: "string",
+          secret: true,
+          title: "E2B / AgentENV API key",
+          description: "Required for E2B Cloud; optional for local AgentENV if auth is disabled.",
+        },
+        apiUrl: {
+          type: "string",
+          title: "AgentENV / E2B API URL",
+          description: "Set this to your AgentENV server URL, for example http://127.0.0.1:8000.",
+        },
+      },
+    },
+    defaultConfig: { apiKey: "", apiUrl: "" },
     mcpServerPresets: [E2B_PRESET],
   } as never,
   activate: async (ctx: PluginContext) => {
     ctx.logger?.info("e2b-sandbox plugin activated")
+    configChangeDispose?.()
+    updateSandboxConnection(ctx.configuration?.getAll?.() ?? ctx.config)
+    configChangeDispose = ctx.configuration?.onChange?.((config) => {
+      updateSandboxConnection(config)
+    })
 
     ctx.agent?.registerMcpServerPreset?.(E2B_PRESET)
 
@@ -86,7 +138,7 @@ const definition: PluginDefinition = {
     // (e.g. a sidecar harness or pre-v0.5 host). Both paths end up in the
     // same `workspace-backend-registry` either way — see
     // `lib/github/workspace.ts:setE2BBackend`.
-    const backend = new E2BWorkspaceBackend()
+    const backend = new E2BWorkspaceBackend({ connection: () => sandboxConnection })
     if (ctx.workspace) {
       const handle = ctx.workspace.registerBackend({
         id: "e2b",
@@ -101,33 +153,38 @@ const definition: PluginDefinition = {
       workspaceRegistrationDispose = () => setE2BBackend(null)
     }
 
+    registerSlashCommand({
+      id: "e2b.attach",
+      name: "/sandbox",
+      description: "Attach the E2B sandbox MCP to the current character.",
+      handler: () => ({
+        message:
+          "Open Settings → MCP Servers, click E2B Sandbox in the gallery, paste your E2B API key, then attach it to the current character.",
+      }),
+      source: "plugin",
+      pluginId: ctx.pluginId,
+    })
+
     // ADR-0028 / T4 — register the microvm exec adapter so any session
     // with `sandboxTier: "microvm"` routes `sandbox_*` tool calls through
     // an ephemeral Firecracker microVM instead of the OS sandbox. When
     // `@e2b/sdk` isn't installed the factory throws a clean install hint
     // at first call — strict-mode compliant (no silent fallback).
-    setMicrovmExec(buildMicrovmExec())
-    // The slash command is DECLARED in plugin.json (`commands[]`) and handled
-    // here — the supported shape per the author-SDK migration table. The
-    // manager owns registration (namespaced id, conflict detection, aliases,
-    // command-palette entry, idle-clock refresh) and teardown.
-    return {
-      onCommand: async (command: string) => {
-        if (command !== "sandbox") return false
-        ctx.ui?.showToast?.(
-          "Open Settings → MCP Servers, click E2B Sandbox in the gallery, paste your E2B API key, then attach it to the current character.",
-          "info"
-        )
-        return true
-      },
-    }
+    setMicrovmExec(buildMicrovmExec({ connection: () => sandboxConnection }))
   },
-  deactivate: async () => {
+  deactivate: async (ctx?: PluginContext) => {
+    if (configChangeDispose) {
+      configChangeDispose()
+      configChangeDispose = undefined
+    }
     if (workspaceRegistrationDispose) {
       workspaceRegistrationDispose()
       workspaceRegistrationDispose = undefined
     }
     setMicrovmExec(null)
+    if (ctx?.pluginId) {
+      unregisterCommandsByPlugin(ctx.pluginId)
+    }
   },
 }
 

--- a/plugins/e2b-sandbox/src/microvm-exec.test.ts
+++ b/plugins/e2b-sandbox/src/microvm-exec.test.ts
@@ -189,4 +189,37 @@ describe("buildMicrovmExec", () => {
     })
     expect(closed.count).toBe(1)
   })
+
+  it("passes AgentENV apiUrl to the sandbox factory as SDK domain", async () => {
+    const { sandbox } = makeSandbox()
+    const sandboxFactory = jest.fn(async () => sandbox)
+    const exec = buildMicrovmExec({
+      apiKey: "key-1",
+      apiUrl: "http://127.0.0.1:8000",
+      sandboxFactory,
+    })
+    await exec({
+      tool: "sandbox_bash",
+      command: {
+        argv: ["true"],
+        cwd: "/",
+        env: {},
+        stdin: null,
+        timeout: 0,
+      },
+      request: {
+        writable: [],
+        readable: [],
+        targetFiles: [],
+        maxCpuSeconds: 0,
+        maxMemoryMb: 0,
+        network: "off",
+        networkHosts: [],
+      },
+    })
+    expect(sandboxFactory).toHaveBeenCalledWith({
+      apiKey: "key-1",
+      domain: "http://127.0.0.1:8000",
+    })
+  })
 })

--- a/plugins/e2b-sandbox/src/microvm-exec.ts
+++ b/plugins/e2b-sandbox/src/microvm-exec.ts
@@ -124,8 +124,8 @@ async function defaultMicrovmSandboxFactory(opts: E2BSandboxConnection): Promise
     )) as { Sandbox?: unknown }
   } catch {
     throw new Error(
-      "@e2b/sdk is not installed. Install it with `pnpm add @e2b/sdk -w` and set " +
-        "E2B_API_KEY to use the microVM sandbox tier."
+      "@e2b/sdk is not installed. Install it with `pnpm add @e2b/sdk -w`, then configure " +
+        "E2B Sandbox in Settings → Plugins."
     )
   }
   const SandboxCtor = mod?.Sandbox as

--- a/plugins/e2b-sandbox/src/microvm-exec.ts
+++ b/plugins/e2b-sandbox/src/microvm-exec.ts
@@ -21,11 +21,18 @@
 
 import type { MicrovmExec, MicrovmExecPayload, MicrovmResult } from "@/lib/sandbox/microvm-bridge"
 
-import type { E2BSandboxFacade, E2BSandboxFactory } from "./workspace-backend"
+import type { E2BSandboxConnection, E2BSandboxFacade, E2BSandboxFactory } from "./workspace-backend"
+import { resolveSandboxConnection } from "./workspace-backend"
 
 export interface MicrovmExecOptions {
   /** API key forwarded to the sandbox factory. */
   apiKey?: string
+  /** E2B-compatible API URL. AgentENV documents this as E2B_API_URL. */
+  apiUrl?: string
+  /** Native @e2b/sdk domain override. Takes precedence over apiUrl. */
+  domain?: string
+  /** Dynamic config resolver used by the plugin settings lifecycle. */
+  connection?: () => E2BSandboxConnection
   /** Factory override — tests inject a mock here. */
   sandboxFactory?: E2BSandboxFactory
   /** Override `Date.now()` for deterministic timing in tests. */
@@ -43,7 +50,7 @@ export function buildMicrovmExec(opts: MicrovmExecOptions = {}): MicrovmExec {
 
   return async function microvmExec(payload: MicrovmExecPayload): Promise<MicrovmResult> {
     const started = now()
-    const sandbox = await factory({ apiKey: opts.apiKey ?? process.env.E2B_API_KEY })
+    const sandbox = await factory(resolveSandboxConnection(opts))
     try {
       const cmd = buildBashCommand(payload)
       const result = await sandbox.exec({
@@ -109,7 +116,7 @@ function escapeShellName(name: string): string {
  * present, so users opting into the microvm tier without the SDK get a
  * clean strict-mode failure rather than a build break.
  */
-async function defaultMicrovmSandboxFactory(opts: { apiKey?: string }): Promise<E2BSandboxFacade> {
+async function defaultMicrovmSandboxFactory(opts: E2BSandboxConnection): Promise<E2BSandboxFacade> {
   let mod: { Sandbox?: unknown } | undefined
   try {
     mod = (await (Function("s", "return import(s)") as (s: string) => Promise<unknown>)(
@@ -126,5 +133,5 @@ async function defaultMicrovmSandboxFactory(opts: { apiKey?: string }): Promise<
   if (!SandboxCtor || typeof SandboxCtor.create !== "function") {
     throw new Error("@e2b/sdk does not export `Sandbox.create` — incompatible SDK version")
   }
-  return SandboxCtor.create({ apiKey: opts.apiKey })
+  return SandboxCtor.create(opts)
 }

--- a/plugins/e2b-sandbox/src/workspace-backend.test.ts
+++ b/plugins/e2b-sandbox/src/workspace-backend.test.ts
@@ -52,32 +52,32 @@ describe("E2BWorkspaceBackend", () => {
     })
   })
 
-  it("resolves E2B_DOMAIN and AgentENV's E2B_API_URL environment aliases", () => {
-    const prevKey = process.env.E2B_API_KEY
-    const prevDomain = process.env.E2B_DOMAIN
-    const prevApiUrl = process.env.E2B_API_URL
-    try {
-      process.env.E2B_API_KEY = "env-key"
-      delete process.env.E2B_DOMAIN
-      process.env.E2B_API_URL = "http://agentenv.local:8000"
-      expect(resolveSandboxConnection({})).toEqual({
-        apiKey: "env-key",
-        domain: "http://agentenv.local:8000",
+  it("prefers trimmed live plugin configuration over construction defaults", () => {
+    expect(
+      resolveSandboxConnection({
+        apiKey: "fallback-key",
+        apiUrl: "https://fallback.example",
+        connection: () => ({
+          apiKey: " live-key ",
+          domain: " http://agentenv.local:8000 ",
+        }),
       })
+    ).toEqual({
+      apiKey: "live-key",
+      domain: "http://agentenv.local:8000",
+    })
+  })
 
-      process.env.E2B_DOMAIN = "https://e2b.example"
-      expect(resolveSandboxConnection({})).toEqual({
-        apiKey: "env-key",
-        domain: "https://e2b.example",
+  it("falls back to explicit options and omits blank values", () => {
+    expect(
+      resolveSandboxConnection({
+        apiKey: " ",
+        domain: "",
+        apiUrl: " http://127.0.0.1:8000 ",
       })
-    } finally {
-      if (prevKey === undefined) delete process.env.E2B_API_KEY
-      else process.env.E2B_API_KEY = prevKey
-      if (prevDomain === undefined) delete process.env.E2B_DOMAIN
-      else process.env.E2B_DOMAIN = prevDomain
-      if (prevApiUrl === undefined) delete process.env.E2B_API_URL
-      else process.env.E2B_API_URL = prevApiUrl
-    }
+    ).toEqual({
+      domain: "http://127.0.0.1:8000",
+    })
   })
 
   it("cleans up the sandbox when clone exec fails", async () => {

--- a/plugins/e2b-sandbox/src/workspace-backend.test.ts
+++ b/plugins/e2b-sandbox/src/workspace-backend.test.ts
@@ -1,4 +1,4 @@
-import { E2BWorkspaceBackend } from "./workspace-backend"
+import { E2BWorkspaceBackend, resolveSandboxConnection } from "./workspace-backend"
 
 function makeSandbox(id: string) {
   const exec = jest.fn(async ({ cmd }: { cmd: string }) => {
@@ -31,6 +31,53 @@ describe("E2BWorkspaceBackend", () => {
     expect(calls.some((c) => c.startsWith("mkdir -p"))).toBe(true)
     expect(calls.some((c) => c.includes("git clone"))).toBe(true)
     expect(calls.some((c) => c.includes("ghs_test"))).toBe(true)
+  })
+
+  it("passes AgentENV apiUrl to the SDK factory as domain", async () => {
+    const sandbox = makeSandbox("sb-agentenv")
+    const sandboxFactory = jest.fn(async () => sandbox)
+    const backend = new E2BWorkspaceBackend({
+      apiKey: "key-1",
+      apiUrl: "http://127.0.0.1:8000",
+      sandboxFactory,
+    })
+    await backend.clone({
+      repoFullName: "octo/hello-world",
+      branch: "main",
+      token: "ghs_test",
+    })
+    expect(sandboxFactory).toHaveBeenCalledWith({
+      apiKey: "key-1",
+      domain: "http://127.0.0.1:8000",
+    })
+  })
+
+  it("resolves E2B_DOMAIN and AgentENV's E2B_API_URL environment aliases", () => {
+    const prevKey = process.env.E2B_API_KEY
+    const prevDomain = process.env.E2B_DOMAIN
+    const prevApiUrl = process.env.E2B_API_URL
+    try {
+      process.env.E2B_API_KEY = "env-key"
+      delete process.env.E2B_DOMAIN
+      process.env.E2B_API_URL = "http://agentenv.local:8000"
+      expect(resolveSandboxConnection({})).toEqual({
+        apiKey: "env-key",
+        domain: "http://agentenv.local:8000",
+      })
+
+      process.env.E2B_DOMAIN = "https://e2b.example"
+      expect(resolveSandboxConnection({})).toEqual({
+        apiKey: "env-key",
+        domain: "https://e2b.example",
+      })
+    } finally {
+      if (prevKey === undefined) delete process.env.E2B_API_KEY
+      else process.env.E2B_API_KEY = prevKey
+      if (prevDomain === undefined) delete process.env.E2B_DOMAIN
+      else process.env.E2B_DOMAIN = prevDomain
+      if (prevApiUrl === undefined) delete process.env.E2B_API_URL
+      else process.env.E2B_API_URL = prevApiUrl
+    }
   })
 
   it("cleans up the sandbox when clone exec fails", async () => {

--- a/plugins/e2b-sandbox/src/workspace-backend.ts
+++ b/plugins/e2b-sandbox/src/workspace-backend.ts
@@ -1,11 +1,11 @@
 /**
- * E2B-backed workspace backend for the GitHub Delivery Issue → PR loop.
+ * E2B-backed workspace backend for Marketplace integrations.
  *
- * The github-delivery plugin exposes `setE2BBackend(impl)` from
- * `lib/github/workspace`. When this plugin (`cognia-e2b-sandbox`) is enabled
- * we register a real implementation so any workflow that sets
- * `worktreeMode: "e2b"` runs the AI loop inside a fresh Firecracker microVM
- * instead of writing to the host filesystem.
+ * The plugin registers this implementation through
+ * `ctx.workspace.registerBackend(...)`. A deprecated `setE2BBackend` shim
+ * remains for older hosts. Integrations that select `worktreeMode: "e2b"`
+ * run their AI loop inside a fresh Firecracker microVM instead of writing to
+ * the host filesystem.
  *
  * Why a separate file in this plugin:
  *   • Keeps `@e2b/sdk` as a peer / optional dep — not every user wants the
@@ -44,7 +44,7 @@ export interface E2BSandboxConnection {
 export type E2BSandboxFactory = (opts: E2BSandboxConnection) => Promise<E2BSandboxFacade>
 
 export interface E2BWorkspaceBackendOptions {
-  /** API key forwarded to the SDK factory. Defaults to process.env.E2B_API_KEY. */
+  /** API key forwarded to the SDK factory. */
   apiKey?: string
   /** E2B-compatible API URL. AgentENV documents this as E2B_API_URL. */
   apiUrl?: string
@@ -174,18 +174,18 @@ function shellEscape(s: string): string {
   return `'${s.replace(/'/g, `'"'"'`)}'`
 }
 
+/**
+ * Resolve the E2B SDK connection from live plugin configuration and explicit
+ * construction options. The frontend plugin cannot read host process
+ * environment variables; MCP subprocess environment is configured separately
+ * by the preset in `index.ts`.
+ */
 export function resolveSandboxConnection(
   opts: Pick<E2BWorkspaceBackendOptions, "apiKey" | "apiUrl" | "domain" | "connection">
 ): E2BSandboxConnection {
   const dynamic = opts.connection?.() ?? {}
-  const apiKey = firstNonEmpty(dynamic.apiKey, opts.apiKey, process.env.E2B_API_KEY)
-  const domain = firstNonEmpty(
-    dynamic.domain,
-    opts.domain,
-    opts.apiUrl,
-    process.env.E2B_DOMAIN,
-    process.env.E2B_API_URL
-  )
+  const apiKey = firstNonEmpty(dynamic.apiKey, opts.apiKey)
+  const domain = firstNonEmpty(dynamic.domain, opts.domain, opts.apiUrl)
   return {
     ...(apiKey ? { apiKey } : {}),
     ...(domain ? { domain } : {}),
@@ -216,7 +216,7 @@ async function defaultSandboxFactory(opts: E2BSandboxConnection): Promise<E2BSan
     )) as { Sandbox?: unknown }
   } catch {
     throw new Error(
-      "@e2b/sdk is not installed. Run `pnpm add @e2b/sdk -w` and set E2B_API_KEY to enable the cloud workspace backend."
+      "@e2b/sdk is not installed. Run `pnpm add @e2b/sdk -w`, then configure E2B Sandbox in Settings → Plugins."
     )
   }
   const SandboxCtor = mod?.Sandbox as

--- a/plugins/e2b-sandbox/src/workspace-backend.ts
+++ b/plugins/e2b-sandbox/src/workspace-backend.ts
@@ -1,14 +1,11 @@
 /**
- * E2B-backed workspace backend for repository automation.
+ * E2B-backed workspace backend for the GitHub Delivery Issue → PR loop.
  *
- * A repository Integration plugin may wire a real implementation through
- * `setE2BBackend(impl)` from `lib/github/workspace`. When this plugin
- * (`cognia-e2b-sandbox`) is enabled we register one, so any workflow that sets
- * `worktreeMode: "e2b"` runs its AI loop inside a fresh Firecracker microVM
- * instead of writing to the host filesystem. (The built-in GitHub Delivery
- * stack that first drove this seam was removed in 2026-07 — see ADR-0018 — but
- * the seam itself is the plugin-facing `provider.workspace-backend` contract
- * and is unaffected.)
+ * The github-delivery plugin exposes `setE2BBackend(impl)` from
+ * `lib/github/workspace`. When this plugin (`cognia-e2b-sandbox`) is enabled
+ * we register a real implementation so any workflow that sets
+ * `worktreeMode: "e2b"` runs the AI loop inside a fresh Firecracker microVM
+ * instead of writing to the host filesystem.
  *
  * Why a separate file in this plugin:
  *   • Keeps `@e2b/sdk` as a peer / optional dep — not every user wants the
@@ -36,12 +33,25 @@ export interface E2BSandboxFacade {
   close(): Promise<void>
 }
 
+/** Connection options forwarded to the E2B-compatible SDK factory. */
+export interface E2BSandboxConnection {
+  apiKey?: string
+  /** SDK option name. AgentENV's `E2B_API_URL` is normalized into this. */
+  domain?: string
+}
+
 /** Factory the backend uses to obtain a fresh sandbox. */
-export type E2BSandboxFactory = (opts: { apiKey?: string }) => Promise<E2BSandboxFacade>
+export type E2BSandboxFactory = (opts: E2BSandboxConnection) => Promise<E2BSandboxFacade>
 
 export interface E2BWorkspaceBackendOptions {
   /** API key forwarded to the SDK factory. Defaults to process.env.E2B_API_KEY. */
   apiKey?: string
+  /** E2B-compatible API URL. AgentENV documents this as E2B_API_URL. */
+  apiUrl?: string
+  /** Native @e2b/sdk domain override. Takes precedence over apiUrl. */
+  domain?: string
+  /** Dynamic config resolver used by the plugin settings lifecycle. */
+  connection?: () => E2BSandboxConnection
   /** Override the sandbox factory — tests inject a mock here. */
   sandboxFactory?: E2BSandboxFactory
   /** Override `Date.now` for deterministic test output. */
@@ -69,7 +79,7 @@ export class E2BWorkspaceBackend implements E2BBackend {
     token: string
   }): Promise<WorkspaceHandle> {
     const factory = this.opts.sandboxFactory ?? defaultSandboxFactory
-    const sandbox = await factory({ apiKey: this.opts.apiKey ?? process.env.E2B_API_KEY })
+    const sandbox = await factory(resolveSandboxConnection(this.opts))
     try {
       // The sandbox starts with a writable working directory; we clone into
       // /tmp/cognia/<repo>/<stamp> so multiple clones in one sandbox lifetime
@@ -164,7 +174,33 @@ function shellEscape(s: string): string {
   return `'${s.replace(/'/g, `'"'"'`)}'`
 }
 
-async function defaultSandboxFactory(opts: { apiKey?: string }): Promise<E2BSandboxFacade> {
+export function resolveSandboxConnection(
+  opts: Pick<E2BWorkspaceBackendOptions, "apiKey" | "apiUrl" | "domain" | "connection">
+): E2BSandboxConnection {
+  const dynamic = opts.connection?.() ?? {}
+  const apiKey = firstNonEmpty(dynamic.apiKey, opts.apiKey, process.env.E2B_API_KEY)
+  const domain = firstNonEmpty(
+    dynamic.domain,
+    opts.domain,
+    opts.apiUrl,
+    process.env.E2B_DOMAIN,
+    process.env.E2B_API_URL
+  )
+  return {
+    ...(apiKey ? { apiKey } : {}),
+    ...(domain ? { domain } : {}),
+  }
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+  return undefined
+}
+
+async function defaultSandboxFactory(opts: E2BSandboxConnection): Promise<E2BSandboxFacade> {
   // Dynamic import keeps `@e2b/sdk` an optional dep. When it's missing we
   // surface a single-line hint pointing users at the install path; the rest
   // of the platform stays usable. Mirrors `microvm-exec.ts`'s default factory:
@@ -188,5 +224,5 @@ async function defaultSandboxFactory(opts: { apiKey?: string }): Promise<E2BSand
   if (!SandboxCtor || typeof SandboxCtor.create !== "function") {
     throw new Error("@e2b/sdk does not export `Sandbox.create` — incompatible SDK version")
   }
-  return SandboxCtor.create({ apiKey: opts.apiKey })
+  return SandboxCtor.create(opts)
 }


### PR DESCRIPTION
## Summary
- add AgentENV/E2B API URL configuration to the E2B sandbox plugin manifest and MCP preset
- pass dynamic plugin configuration into workspace backend and microVM exec as the SDK domain override
- document AgentENV setup and env fallbacks in English and Chinese sandbox docs

## Validation
- pnpm test plugins/e2b-sandbox/src/index.test.ts plugins/e2b-sandbox/src/microvm-exec.test.ts plugins/e2b-sandbox/src/workspace-backend.test.ts --runInBand
- pnpm exec eslint plugins/e2b-sandbox/src/index.ts plugins/e2b-sandbox/src/microvm-exec.ts plugins/e2b-sandbox/src/workspace-backend.ts plugins/e2b-sandbox/src/index.test.ts plugins/e2b-sandbox/src/microvm-exec.test.ts plugins/e2b-sandbox/src/workspace-backend.test.ts
- attempted official AgentENV server startup locally: native ARM64 image pull has no manifest; amd64 image starts under qemu but /health resets and logs qemu SIGSEGV on this macOS ARM64 Docker Desktop host

## Notes
- full repo typecheck was intentionally not run; this PR keeps validation scoped to the AgentENV plugin path